### PR TITLE
travis: Fix definition of environment vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: rust
 
 env:
-    RUST_MIN_STACK: 8192000
-    RUSTFLAGS: "-C link-args=-Wl,-zstack-size=8000000"
-    RUSTDOCFLAGS: "-C link-args=-Wl,-zstack-size=8000000"
+  RUST_MIN_STACK=8192000
+  RUSTFLAGS="-C link-args=-Wl,-zstack-size=8000000"
+  RUSTDOCFLAGS="-C link-args=-Wl,-zstack-size=8000000"
 
 os:
  - linux


### PR DESCRIPTION
This PR fixes the `.travis.yml` file, such that now the environment variables are correctly defined.

Blocks https://github.com/mcginty/snow/pull/61