### PR TITLE
add optional Zeroize implementation to all crates

### DIFF
--- a/pqcrypto-classicmceliece/Cargo.toml
+++ b/pqcrypto-classicmceliece/Cargo.toml
@@ -14,7 +14,11 @@ categories = ["cryptography"]
 [dependencies]
 pqcrypto-traits = {path = "../pqcrypto-traits", version = "0.3.2"}
 libc = "0.2.0"
+zeroize = { version = "1.2.0", optional = true }
 
+[features]
+default = ["avx2"]
+avx2 = []
 
 [dev-dependencies]
 
@@ -26,7 +30,3 @@ glob = "0.3.0"
 travis-ci = { repository = "rustpq/pqcrypto", branch = "master" }
 maintenance = { status = "actively-developed" }
 
-
-[features]
-default = ["avx2"]
-avx2 = []

--- a/pqcrypto-classicmceliece/src/mceliece348864.rs
+++ b/pqcrypto-classicmceliece/src/mceliece348864.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-classicmceliece/src/mceliece348864f.rs
+++ b/pqcrypto-classicmceliece/src/mceliece348864f.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-classicmceliece/src/mceliece460896.rs
+++ b/pqcrypto-classicmceliece/src/mceliece460896.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-classicmceliece/src/mceliece460896f.rs
+++ b/pqcrypto-classicmceliece/src/mceliece460896f.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-classicmceliece/src/mceliece6688128.rs
+++ b/pqcrypto-classicmceliece/src/mceliece6688128.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-classicmceliece/src/mceliece6688128f.rs
+++ b/pqcrypto-classicmceliece/src/mceliece6688128f.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-classicmceliece/src/mceliece6960119.rs
+++ b/pqcrypto-classicmceliece/src/mceliece6960119.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-classicmceliece/src/mceliece6960119f.rs
+++ b/pqcrypto-classicmceliece/src/mceliece6960119f.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-classicmceliece/src/mceliece8192128.rs
+++ b/pqcrypto-classicmceliece/src/mceliece8192128.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-classicmceliece/src/mceliece8192128f.rs
+++ b/pqcrypto-classicmceliece/src/mceliece8192128f.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-dilithium/Cargo.toml
+++ b/pqcrypto-dilithium/Cargo.toml
@@ -14,7 +14,11 @@ categories = ["cryptography"]
 [dependencies]
 pqcrypto-traits = {path = "../pqcrypto-traits", version = "0.3.2"}
 libc = "0.2.0"
+zeroize = { version = "1.2.0", optional = true }
 
+[features]
+default = ["avx2"]
+avx2 = []
 
 [dev-dependencies]
 rand = "0.7.0"
@@ -27,7 +31,3 @@ glob = "0.3.0"
 travis-ci = { repository = "rustpq/pqcrypto", branch = "master" }
 maintenance = { status = "actively-developed" }
 
-
-[features]
-default = ["avx2"]
-avx2 = []

--- a/pqcrypto-dilithium/src/dilithium2.rs
+++ b/pqcrypto-dilithium/src/dilithium2.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-dilithium/src/dilithium3.rs
+++ b/pqcrypto-dilithium/src/dilithium3.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-dilithium/src/dilithium4.rs
+++ b/pqcrypto-dilithium/src/dilithium4.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-falcon/Cargo.toml
+++ b/pqcrypto-falcon/Cargo.toml
@@ -14,7 +14,10 @@ categories = ["cryptography"]
 [dependencies]
 pqcrypto-traits = {path = "../pqcrypto-traits", version = "0.3.2"}
 libc = "0.2.0"
+zeroize = { version = "1.2.0", optional = true }
 
+[features]
+default = []
 
 [dev-dependencies]
 rand = "0.7.0"
@@ -26,5 +29,4 @@ glob = "0.3.0"
 [badges]
 travis-ci = { repository = "rustpq/pqcrypto", branch = "master" }
 maintenance = { status = "actively-developed" }
-
 

--- a/pqcrypto-falcon/src/falcon1024.rs
+++ b/pqcrypto-falcon/src/falcon1024.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-falcon/src/falcon512.rs
+++ b/pqcrypto-falcon/src/falcon512.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-frodo/Cargo.toml
+++ b/pqcrypto-frodo/Cargo.toml
@@ -14,7 +14,10 @@ categories = ["cryptography"]
 [dependencies]
 pqcrypto-traits = {path = "../pqcrypto-traits", version = "0.3.2"}
 libc = "0.2.0"
+zeroize = { version = "1.2.0", optional = true }
 
+[features]
+default = []
 
 [dev-dependencies]
 
@@ -25,5 +28,4 @@ glob = "0.3.0"
 [badges]
 travis-ci = { repository = "rustpq/pqcrypto", branch = "master" }
 maintenance = { status = "actively-developed" }
-
 

--- a/pqcrypto-frodo/src/frodokem1344aes.rs
+++ b/pqcrypto-frodo/src/frodokem1344aes.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-frodo/src/frodokem1344shake.rs
+++ b/pqcrypto-frodo/src/frodokem1344shake.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-frodo/src/frodokem640aes.rs
+++ b/pqcrypto-frodo/src/frodokem640aes.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-frodo/src/frodokem640shake.rs
+++ b/pqcrypto-frodo/src/frodokem640shake.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-frodo/src/frodokem976aes.rs
+++ b/pqcrypto-frodo/src/frodokem976aes.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-frodo/src/frodokem976shake.rs
+++ b/pqcrypto-frodo/src/frodokem976shake.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-hqc/Cargo.toml
+++ b/pqcrypto-hqc/Cargo.toml
@@ -14,7 +14,10 @@ categories = ["cryptography"]
 [dependencies]
 pqcrypto-traits = {path = "../pqcrypto-traits", version = "0.3.2"}
 libc = "0.2.0"
+zeroize = { version = "1.2.0", optional = true }
 
+[features]
+default = []
 
 [dev-dependencies]
 
@@ -25,5 +28,4 @@ glob = "0.3.0"
 [badges]
 travis-ci = { repository = "rustpq/pqcrypto", branch = "master" }
 maintenance = { status = "actively-developed" }
-
 

--- a/pqcrypto-hqc/src/hqc1281cca2.rs
+++ b/pqcrypto-hqc/src/hqc1281cca2.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-hqc/src/hqc1921cca2.rs
+++ b/pqcrypto-hqc/src/hqc1921cca2.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-hqc/src/hqc1922cca2.rs
+++ b/pqcrypto-hqc/src/hqc1922cca2.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-hqc/src/hqc2561cca2.rs
+++ b/pqcrypto-hqc/src/hqc2561cca2.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-hqc/src/hqc2562cca2.rs
+++ b/pqcrypto-hqc/src/hqc2562cca2.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-hqc/src/hqc2563cca2.rs
+++ b/pqcrypto-hqc/src/hqc2563cca2.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-kyber/Cargo.toml
+++ b/pqcrypto-kyber/Cargo.toml
@@ -14,7 +14,11 @@ categories = ["cryptography"]
 [dependencies]
 pqcrypto-traits = {path = "../pqcrypto-traits", version = "0.3.2"}
 libc = "0.2.0"
+zeroize = { version = "1.2.0", optional = true }
 
+[features]
+default = ["avx2"]
+avx2 = []
 
 [dev-dependencies]
 
@@ -26,7 +30,3 @@ glob = "0.3.0"
 travis-ci = { repository = "rustpq/pqcrypto", branch = "master" }
 maintenance = { status = "actively-developed" }
 
-
-[features]
-default = ["avx2"]
-avx2 = []

--- a/pqcrypto-kyber/src/kyber1024.rs
+++ b/pqcrypto-kyber/src/kyber1024.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-kyber/src/kyber102490s.rs
+++ b/pqcrypto-kyber/src/kyber102490s.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-kyber/src/kyber512.rs
+++ b/pqcrypto-kyber/src/kyber512.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-kyber/src/kyber51290s.rs
+++ b/pqcrypto-kyber/src/kyber51290s.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-kyber/src/kyber768.rs
+++ b/pqcrypto-kyber/src/kyber768.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-kyber/src/kyber76890s.rs
+++ b/pqcrypto-kyber/src/kyber76890s.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-ntru/Cargo.toml
+++ b/pqcrypto-ntru/Cargo.toml
@@ -14,7 +14,11 @@ categories = ["cryptography"]
 [dependencies]
 pqcrypto-traits = {path = "../pqcrypto-traits", version = "0.3.2"}
 libc = "0.2.0"
+zeroize = { version = "1.2.0", optional = true }
 
+[features]
+default = ["avx2"]
+avx2 = []
 
 [dev-dependencies]
 
@@ -26,7 +30,3 @@ glob = "0.3.0"
 travis-ci = { repository = "rustpq/pqcrypto", branch = "master" }
 maintenance = { status = "actively-developed" }
 
-
-[features]
-default = ["avx2"]
-avx2 = []

--- a/pqcrypto-ntru/src/ntruhps2048509.rs
+++ b/pqcrypto-ntru/src/ntruhps2048509.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-ntru/src/ntruhps2048677.rs
+++ b/pqcrypto-ntru/src/ntruhps2048677.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-ntru/src/ntruhps4096821.rs
+++ b/pqcrypto-ntru/src/ntruhps4096821.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-ntru/src/ntruhrss701.rs
+++ b/pqcrypto-ntru/src/ntruhrss701.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-rainbow/Cargo.toml
+++ b/pqcrypto-rainbow/Cargo.toml
@@ -14,7 +14,10 @@ categories = ["cryptography"]
 [dependencies]
 pqcrypto-traits = {path = "../pqcrypto-traits", version = "0.3.2"}
 libc = "0.2.0"
+zeroize = { version = "1.2.0", optional = true }
 
+[features]
+default = []
 
 [dev-dependencies]
 rand = "0.7.0"
@@ -26,5 +29,4 @@ glob = "0.3.0"
 [badges]
 travis-ci = { repository = "rustpq/pqcrypto", branch = "master" }
 maintenance = { status = "actively-developed" }
-
 

--- a/pqcrypto-rainbow/src/rainbowiaclassic.rs
+++ b/pqcrypto-rainbow/src/rainbowiaclassic.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-rainbow/src/rainbowiacyclic.rs
+++ b/pqcrypto-rainbow/src/rainbowiacyclic.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-rainbow/src/rainbowiacycliccompressed.rs
+++ b/pqcrypto-rainbow/src/rainbowiacycliccompressed.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-rainbow/src/rainbowiiicclassic.rs
+++ b/pqcrypto-rainbow/src/rainbowiiicclassic.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-rainbow/src/rainbowiiiccyclic.rs
+++ b/pqcrypto-rainbow/src/rainbowiiiccyclic.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-rainbow/src/rainbowiiiccycliccompressed.rs
+++ b/pqcrypto-rainbow/src/rainbowiiiccycliccompressed.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-rainbow/src/rainbowvcclassic.rs
+++ b/pqcrypto-rainbow/src/rainbowvcclassic.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-rainbow/src/rainbowvccyclic.rs
+++ b/pqcrypto-rainbow/src/rainbowvccyclic.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-rainbow/src/rainbowvccycliccompressed.rs
+++ b/pqcrypto-rainbow/src/rainbowvccycliccompressed.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-saber/Cargo.toml
+++ b/pqcrypto-saber/Cargo.toml
@@ -14,7 +14,10 @@ categories = ["cryptography"]
 [dependencies]
 pqcrypto-traits = {path = "../pqcrypto-traits", version = "0.3.2"}
 libc = "0.2.0"
+zeroize = { version = "1.2.0", optional = true }
 
+[features]
+default = []
 
 [dev-dependencies]
 
@@ -25,5 +28,4 @@ glob = "0.3.0"
 [badges]
 travis-ci = { repository = "rustpq/pqcrypto", branch = "master" }
 maintenance = { status = "actively-developed" }
-
 

--- a/pqcrypto-saber/src/firesaber.rs
+++ b/pqcrypto-saber/src/firesaber.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-saber/src/lightsaber.rs
+++ b/pqcrypto-saber/src/lightsaber.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-saber/src/saber.rs
+++ b/pqcrypto-saber/src/saber.rs
@@ -68,6 +68,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/Cargo.toml
+++ b/pqcrypto-sphincsplus/Cargo.toml
@@ -14,7 +14,11 @@ categories = ["cryptography"]
 [dependencies]
 pqcrypto-traits = {path = "../pqcrypto-traits", version = "0.3.2"}
 libc = "0.2.0"
+zeroize = { version = "1.2.0", optional = true }
 
+[features]
+default = ["avx2"]
+avx2 = []
 
 [dev-dependencies]
 rand = "0.7.0"
@@ -27,7 +31,3 @@ glob = "0.3.0"
 travis-ci = { repository = "rustpq/pqcrypto", branch = "master" }
 maintenance = { status = "actively-developed" }
 
-
-[features]
-default = ["avx2"]
-avx2 = []

--- a/pqcrypto-sphincsplus/src/sphincsharaka128frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka128frobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsharaka128fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka128fsimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsharaka128srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka128srobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsharaka128ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka128ssimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsharaka192frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka192frobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsharaka192fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka192fsimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsharaka192srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka192srobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsharaka192ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka192ssimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsharaka256frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka256frobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsharaka256fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka256fsimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsharaka256srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka256srobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsharaka256ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka256ssimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincssha256128frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256128frobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincssha256128fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256128fsimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincssha256128srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256128srobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincssha256128ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256128ssimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincssha256192frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256192frobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincssha256192fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256192fsimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincssha256192srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256192srobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincssha256192ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256192ssimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincssha256256frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256256frobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincssha256256fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256256fsimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincssha256256srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256256srobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincssha256256ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256256ssimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsshake256128frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256128frobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsshake256128fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256128fsimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsshake256128srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256128srobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsshake256128ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256128ssimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsshake256192frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256192frobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsshake256192fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256192fsimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsshake256192srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256192srobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsshake256192ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256192ssimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsshake256256frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256256frobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsshake256256fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256256fsimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsshake256256srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256256srobust.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-sphincsplus/src/sphincsshake256256ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256256ssimple.rs
@@ -69,6 +69,13 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0.iter_mut().for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto-template/pqcrypto/Cargo.toml.j2
+++ b/pqcrypto-template/pqcrypto/Cargo.toml.j2
@@ -18,8 +18,9 @@ pqcrypto-{{ name }} = { path = "../pqcrypto-{{ name }}", version = "{{ props.ver
 {% endfor %}
 
 [features]
-default = [{% for (name, props) in kems.items()|list + signs.items()|list %}{% if not props.insecure|default(False) %}"pqcrypto-{{name}}",{% endif %}{% endfor %}]
+default = [{% for (name, props) in kems.items()|list + signs.items()|list %}{% if not props.insecure|default(False) %}"pqcrypto-{{name}}",{% endif %}{% endfor %}"zeroize"]
 cryptographically-insecure = [{% for (name, props) in kems.items()|list + signs.items()|list %}{% if props.insecure|default(False) %}"pqcrypto-{{name}}/cryptographically-insecure",{% endif %}{% endfor %}]
+zeroize = [{% for (name, props) in kems.items()|list + signs.items()|list %}"pqcrypto-{{ name }}/zeroize",{% endfor %}]
 
 [badges]
 travis-ci = { repository = "rustpq/pqcrypto", branch = "master" }

--- a/pqcrypto-template/scheme/Cargo.toml.j2
+++ b/pqcrypto-template/scheme/Cargo.toml.j2
@@ -14,10 +14,16 @@ categories = ["cryptography"]
 [dependencies]
 pqcrypto-traits = {path = "../pqcrypto-traits", version = "{{ traits_version }}"}
 libc = "0.2.0"
+zeroize = { version = "1.2.0", optional = true }
 
-{% if insecure %}
 [features]
+{% if has_avx2 %}
+default = ["avx2"]
+avx2 = []
+{% else %}
 default = []
+{% endif %}
+{% if insecure %}
 cryptographically-insecure = []
 {% endif %}
 
@@ -37,10 +43,4 @@ maintenance = { status = "actively-developed" }
 {% if insecure %}
 [package.metadata.docs.rs]
 features = ["cryptographically-insecure"]
-{% endif %}
-
-{% if has_avx2 %}
-[features]
-default = ["avx2"]
-avx2 = []
 {% endif %}

--- a/pqcrypto-template/scheme/src/scheme.rs.j2
+++ b/pqcrypto-template/scheme/src/scheme.rs.j2
@@ -82,6 +82,15 @@ macro_rules! simple_struct {
                     .is_ok()
             }
         }
+
+        #[cfg(feature = "zeroize")]
+        impl zeroize::Zeroize for $type {
+            fn zeroize(&mut self) {
+                self.0
+                    .iter_mut()
+                    .for_each(zeroize::Zeroize::zeroize);
+            }
+        }
     };
 }
 

--- a/pqcrypto/Cargo.toml
+++ b/pqcrypto/Cargo.toml
@@ -25,8 +25,9 @@ pqcrypto-rainbow = { path = "../pqcrypto-rainbow", version = "0.1.3", optional =
 pqcrypto-sphincsplus = { path = "../pqcrypto-sphincsplus", version = "0.5.2", optional = true }
 
 [features]
-default = ["pqcrypto-kyber","pqcrypto-frodo","pqcrypto-ntru","pqcrypto-saber","pqcrypto-classicmceliece","pqcrypto-hqc","pqcrypto-dilithium","pqcrypto-falcon","pqcrypto-rainbow","pqcrypto-sphincsplus",]
+default = ["pqcrypto-kyber","pqcrypto-frodo","pqcrypto-ntru","pqcrypto-saber","pqcrypto-classicmceliece","pqcrypto-hqc","pqcrypto-dilithium","pqcrypto-falcon","pqcrypto-rainbow","pqcrypto-sphincsplus","zeroize"]
 cryptographically-insecure = []
+zeroize = ["pqcrypto-kyber/zeroize","pqcrypto-frodo/zeroize","pqcrypto-ntru/zeroize","pqcrypto-saber/zeroize","pqcrypto-classicmceliece/zeroize","pqcrypto-hqc/zeroize","pqcrypto-dilithium/zeroize","pqcrypto-falcon/zeroize","pqcrypto-rainbow/zeroize","pqcrypto-sphincsplus/zeroize",]
 
 [badges]
 travis-ci = { repository = "rustpq/pqcrypto", branch = "master" }


### PR DESCRIPTION
This adds a `zeroize` feature to all crates, which enabled, implements [`zeroize::Zeroize`](https://docs.rs/zeroize/1.2.0/zeroize/trait.Zeroize.html) on all structs made via the `simple_struct!` macro - which is most public/private key structs, allowing for secure (won't be optimized out) zeroization for all in-memory keys.