### PR TITLE
Move wrapper methods to macros

### DIFF
--- a/pqcrypto-classicmceliece/src/mceliece348864.rs
+++ b/pqcrypto-classicmceliece/src/mceliece348864.rs
@@ -113,40 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_MCELIECE348864_VEC_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a mceliece348864 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_MCELIECE348864_AVX_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_MCELIECE348864_VEC_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE348864_VEC_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE348864_AVX_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a mceliece348864 public key
@@ -154,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_MCELIECE348864_AVX_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_MCELIECE348864_VEC_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE348864_VEC_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE348864_AVX_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received mceliece348864 ciphertext
@@ -204,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_MCELIECE348864_AVX_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE348864_VEC_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE348864_AVX_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_MCELIECE348864_VEC_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-classicmceliece/src/mceliece348864f.rs
+++ b/pqcrypto-classicmceliece/src/mceliece348864f.rs
@@ -113,43 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_MCELIECE348864F_VEC_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a mceliece348864f keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_MCELIECE348864F_AVX_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_MCELIECE348864F_VEC_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE348864F_VEC_crypto_kem_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE348864F_AVX_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a mceliece348864f public key
@@ -157,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_MCELIECE348864F_AVX_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_MCELIECE348864F_VEC_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE348864F_VEC_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE348864F_AVX_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received mceliece348864f ciphertext
@@ -207,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_MCELIECE348864F_AVX_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE348864F_VEC_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE348864F_AVX_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_MCELIECE348864F_VEC_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-classicmceliece/src/mceliece460896.rs
+++ b/pqcrypto-classicmceliece/src/mceliece460896.rs
@@ -113,40 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_MCELIECE460896_VEC_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a mceliece460896 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_MCELIECE460896_AVX_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_MCELIECE460896_VEC_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE460896_VEC_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE460896_AVX_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a mceliece460896 public key
@@ -154,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_MCELIECE460896_AVX_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_MCELIECE460896_VEC_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE460896_VEC_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE460896_AVX_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received mceliece460896 ciphertext
@@ -204,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_MCELIECE460896_AVX_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE460896_VEC_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE460896_AVX_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_MCELIECE460896_VEC_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-classicmceliece/src/mceliece6688128.rs
+++ b/pqcrypto-classicmceliece/src/mceliece6688128.rs
@@ -113,43 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_MCELIECE6688128_VEC_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a mceliece6688128 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_MCELIECE6688128_AVX_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_MCELIECE6688128_VEC_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE6688128_VEC_crypto_kem_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE6688128_AVX_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a mceliece6688128 public key
@@ -157,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_MCELIECE6688128_AVX_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_MCELIECE6688128_VEC_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE6688128_VEC_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE6688128_AVX_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received mceliece6688128 ciphertext
@@ -207,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_MCELIECE6688128_AVX_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE6688128_VEC_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE6688128_AVX_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_MCELIECE6688128_VEC_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-classicmceliece/src/mceliece6688128f.rs
+++ b/pqcrypto-classicmceliece/src/mceliece6688128f.rs
@@ -113,43 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_MCELIECE6688128F_VEC_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a mceliece6688128f keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_MCELIECE6688128F_AVX_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_MCELIECE6688128F_VEC_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE6688128F_VEC_crypto_kem_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE6688128F_AVX_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a mceliece6688128f public key
@@ -157,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_MCELIECE6688128F_AVX_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_MCELIECE6688128F_VEC_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE6688128F_VEC_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE6688128F_AVX_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received mceliece6688128f ciphertext
@@ -207,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_MCELIECE6688128F_AVX_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE6688128F_VEC_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE6688128F_AVX_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_MCELIECE6688128F_VEC_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-classicmceliece/src/mceliece6960119.rs
+++ b/pqcrypto-classicmceliece/src/mceliece6960119.rs
@@ -113,43 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_MCELIECE6960119_VEC_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a mceliece6960119 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_MCELIECE6960119_AVX_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_MCELIECE6960119_VEC_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE6960119_VEC_crypto_kem_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE6960119_AVX_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a mceliece6960119 public key
@@ -157,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_MCELIECE6960119_AVX_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_MCELIECE6960119_VEC_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE6960119_VEC_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE6960119_AVX_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received mceliece6960119 ciphertext
@@ -207,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_MCELIECE6960119_AVX_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE6960119_VEC_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE6960119_AVX_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_MCELIECE6960119_VEC_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-classicmceliece/src/mceliece6960119f.rs
+++ b/pqcrypto-classicmceliece/src/mceliece6960119f.rs
@@ -113,43 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_MCELIECE6960119F_VEC_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a mceliece6960119f keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_MCELIECE6960119F_AVX_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_MCELIECE6960119F_VEC_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE6960119F_VEC_crypto_kem_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE6960119F_AVX_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a mceliece6960119f public key
@@ -157,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_MCELIECE6960119F_AVX_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_MCELIECE6960119F_VEC_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE6960119F_VEC_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE6960119F_AVX_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received mceliece6960119f ciphertext
@@ -207,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_MCELIECE6960119F_AVX_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE6960119F_VEC_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE6960119F_AVX_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_MCELIECE6960119F_VEC_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-classicmceliece/src/mceliece8192128.rs
+++ b/pqcrypto-classicmceliece/src/mceliece8192128.rs
@@ -113,43 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_MCELIECE8192128_VEC_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a mceliece8192128 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_MCELIECE8192128_AVX_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_MCELIECE8192128_VEC_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE8192128_VEC_crypto_kem_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE8192128_AVX_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a mceliece8192128 public key
@@ -157,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_MCELIECE8192128_AVX_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_MCELIECE8192128_VEC_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE8192128_VEC_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE8192128_AVX_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received mceliece8192128 ciphertext
@@ -207,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_MCELIECE8192128_AVX_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE8192128_VEC_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE8192128_AVX_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_MCELIECE8192128_VEC_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-classicmceliece/src/mceliece8192128f.rs
+++ b/pqcrypto-classicmceliece/src/mceliece8192128f.rs
@@ -113,43 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_MCELIECE8192128F_VEC_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a mceliece8192128f keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_MCELIECE8192128F_AVX_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_MCELIECE8192128F_VEC_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE8192128F_VEC_crypto_kem_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE8192128F_AVX_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a mceliece8192128f public key
@@ -157,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_MCELIECE8192128F_AVX_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_MCELIECE8192128F_VEC_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE8192128F_VEC_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE8192128F_AVX_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received mceliece8192128f ciphertext
@@ -207,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_MCELIECE8192128F_AVX_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_MCELIECE8192128F_VEC_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_MCELIECE8192128F_AVX_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_MCELIECE8192128F_VEC_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-dilithium/src/dilithium2.rs
+++ b/pqcrypto-dilithium/src/dilithium2.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -165,40 +166,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a dilithium2 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_DILITHIUM2_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_DILITHIUM2_AVX2_crypto_sign_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -206,52 +214,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_DILITHIUM2_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_DILITHIUM2_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_DILITHIUM2_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_DILITHIUM2_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -259,60 +251,26 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(PQCLEAN_DILITHIUM2_AVX2_crypto_sign_open, sm, pk);
         }
     }
-    open_portable(sm, pk)
+    open_signed!(PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_open, sm, pk)
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_DILITHIUM2_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -320,41 +278,29 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(PQCLEAN_DILITHIUM2_AVX2_crypto_sign_signature, msg, sk);
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_signature, msg, sk)
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_DILITHIUM2_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -366,54 +312,10 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(PQCLEAN_DILITHIUM2_AVX2_crypto_sign_verify, sig, msg, pk);
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_DILITHIUM2_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_verify, sig, msg, pk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-dilithium/src/dilithium3.rs
+++ b/pqcrypto-dilithium/src/dilithium3.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -165,40 +166,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a dilithium3 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_DILITHIUM3_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_DILITHIUM3_AVX2_crypto_sign_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -206,52 +214,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_DILITHIUM3_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_DILITHIUM3_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_DILITHIUM3_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_DILITHIUM3_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -259,60 +251,26 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(PQCLEAN_DILITHIUM3_AVX2_crypto_sign_open, sm, pk);
         }
     }
-    open_portable(sm, pk)
+    open_signed!(PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_open, sm, pk)
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_DILITHIUM3_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -320,41 +278,29 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(PQCLEAN_DILITHIUM3_AVX2_crypto_sign_signature, msg, sk);
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_signature, msg, sk)
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_DILITHIUM3_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -366,54 +312,10 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(PQCLEAN_DILITHIUM3_AVX2_crypto_sign_verify, sig, msg, pk);
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_DILITHIUM3_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_verify, sig, msg, pk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-dilithium/src/dilithium5.rs
+++ b/pqcrypto-dilithium/src/dilithium5.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -165,40 +166,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a dilithium5 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_DILITHIUM5_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_DILITHIUM5_AVX2_crypto_sign_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -206,52 +214,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_DILITHIUM5_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_DILITHIUM5_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_DILITHIUM5_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_DILITHIUM5_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -259,60 +251,26 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(PQCLEAN_DILITHIUM5_AVX2_crypto_sign_open, sm, pk);
         }
     }
-    open_portable(sm, pk)
+    open_signed!(PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_open, sm, pk)
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_DILITHIUM5_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -320,41 +278,29 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(PQCLEAN_DILITHIUM5_AVX2_crypto_sign_signature, msg, sk);
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_signature, msg, sk)
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_DILITHIUM5_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -366,54 +312,10 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(PQCLEAN_DILITHIUM5_AVX2_crypto_sign_verify, sig, msg, pk);
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_DILITHIUM5_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_verify, sig, msg, pk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-falcon/src/falcon1024.rs
+++ b/pqcrypto-falcon/src/falcon1024.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -165,98 +166,117 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_FALCON1024_CLEAN_CRYPTO_BYTES
 }
 
-/// Generate a falcon-1024 keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+/// Generate a falcon-1024 keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair)
+}
+
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
 pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_FALCON1024_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_FALCON1024_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
 ) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    open_portable(sm, pk)
+    open_signed!(PQCLEAN_FALCON1024_CLEAN_crypto_sign_open, sm, pk)
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_FALCON1024_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
 pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    detached_sign_portable(msg, sk)
+    detached_signature!(PQCLEAN_FALCON1024_CLEAN_crypto_sign_signature, msg, sk)
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_FALCON1024_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -265,28 +285,7 @@ pub fn verify_detached_signature(
     msg: &[u8],
     pk: &PublicKey,
 ) -> std::result::Result<(), primitive::VerificationError> {
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_FALCON1024_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(PQCLEAN_FALCON1024_CLEAN_crypto_sign_verify, sig, msg, pk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-falcon/src/falcon512.rs
+++ b/pqcrypto-falcon/src/falcon512.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -165,98 +166,117 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_FALCON512_CLEAN_CRYPTO_BYTES
 }
 
-/// Generate a falcon-512 keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+/// Generate a falcon-512 keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair)
+}
+
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
 pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_FALCON512_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_FALCON512_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
 ) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    open_portable(sm, pk)
+    open_signed!(PQCLEAN_FALCON512_CLEAN_crypto_sign_open, sm, pk)
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_FALCON512_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
 pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    detached_sign_portable(msg, sk)
+    detached_signature!(PQCLEAN_FALCON512_CLEAN_crypto_sign_signature, msg, sk)
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_FALCON512_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -265,28 +285,7 @@ pub fn verify_detached_signature(
     msg: &[u8],
     pk: &PublicKey,
 ) -> std::result::Result<(), primitive::VerificationError> {
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_FALCON512_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(PQCLEAN_FALCON512_CLEAN_crypto_sign_verify, sig, msg, pk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-frodo/src/frodokem1344aes.rs
+++ b/pqcrypto-frodo/src/frodokem1344aes.rs
@@ -113,70 +113,54 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_FRODOKEM1344AES_OPT_CRYPTO_BYTES
 }
 
-/// Generate a frodokem1344aes keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FRODOKEM1344AES_OPT_crypto_kem_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
+/// Generate a frodokem1344aes keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_FRODOKEM1344AES_OPT_crypto_kem_keypair)
+}
+
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a frodokem1344aes public key
 pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_FRODOKEM1344AES_OPT_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FRODOKEM1344AES_OPT_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received frodokem1344aes ciphertext
 pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FRODOKEM1344AES_OPT_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
+    decap!(PQCLEAN_FRODOKEM1344AES_OPT_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-frodo/src/frodokem1344shake.rs
+++ b/pqcrypto-frodo/src/frodokem1344shake.rs
@@ -116,70 +116,54 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_FRODOKEM1344SHAKE_OPT_CRYPTO_BYTES
 }
 
-/// Generate a frodokem1344shake keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FRODOKEM1344SHAKE_OPT_crypto_kem_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
+/// Generate a frodokem1344shake keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_FRODOKEM1344SHAKE_OPT_crypto_kem_keypair)
+}
+
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a frodokem1344shake public key
 pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_FRODOKEM1344SHAKE_OPT_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FRODOKEM1344SHAKE_OPT_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received frodokem1344shake ciphertext
 pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FRODOKEM1344SHAKE_OPT_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
+    decap!(PQCLEAN_FRODOKEM1344SHAKE_OPT_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-frodo/src/frodokem640aes.rs
+++ b/pqcrypto-frodo/src/frodokem640aes.rs
@@ -113,67 +113,54 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_FRODOKEM640AES_OPT_CRYPTO_BYTES
 }
 
-/// Generate a frodokem640aes keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FRODOKEM640AES_OPT_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
+/// Generate a frodokem640aes keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_FRODOKEM640AES_OPT_crypto_kem_keypair)
+}
+
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a frodokem640aes public key
 pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_FRODOKEM640AES_OPT_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FRODOKEM640AES_OPT_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received frodokem640aes ciphertext
 pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FRODOKEM640AES_OPT_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
+    decap!(PQCLEAN_FRODOKEM640AES_OPT_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-frodo/src/frodokem640shake.rs
+++ b/pqcrypto-frodo/src/frodokem640shake.rs
@@ -113,70 +113,54 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_FRODOKEM640SHAKE_OPT_CRYPTO_BYTES
 }
 
-/// Generate a frodokem640shake keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FRODOKEM640SHAKE_OPT_crypto_kem_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
+/// Generate a frodokem640shake keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_FRODOKEM640SHAKE_OPT_crypto_kem_keypair)
+}
+
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a frodokem640shake public key
 pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_FRODOKEM640SHAKE_OPT_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FRODOKEM640SHAKE_OPT_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received frodokem640shake ciphertext
 pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FRODOKEM640SHAKE_OPT_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
+    decap!(PQCLEAN_FRODOKEM640SHAKE_OPT_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-frodo/src/frodokem976aes.rs
+++ b/pqcrypto-frodo/src/frodokem976aes.rs
@@ -113,67 +113,54 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_FRODOKEM976AES_OPT_CRYPTO_BYTES
 }
 
-/// Generate a frodokem976aes keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FRODOKEM976AES_OPT_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
+/// Generate a frodokem976aes keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_FRODOKEM976AES_OPT_crypto_kem_keypair)
+}
+
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a frodokem976aes public key
 pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_FRODOKEM976AES_OPT_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FRODOKEM976AES_OPT_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received frodokem976aes ciphertext
 pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FRODOKEM976AES_OPT_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
+    decap!(PQCLEAN_FRODOKEM976AES_OPT_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-hqc/src/hqcrmrs128.rs
+++ b/pqcrypto-hqc/src/hqcrmrs128.rs
@@ -113,67 +113,54 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_HQCRMRS128_CLEAN_CRYPTO_BYTES
 }
 
-/// Generate a hqc-rmrs-128 keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_HQCRMRS128_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
+/// Generate a hqc-rmrs-128 keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_HQCRMRS128_CLEAN_crypto_kem_keypair)
+}
+
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a hqc-rmrs-128 public key
 pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_HQCRMRS128_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_HQCRMRS128_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received hqc-rmrs-128 ciphertext
 pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_HQCRMRS128_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
+    decap!(PQCLEAN_HQCRMRS128_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-hqc/src/hqcrmrs192.rs
+++ b/pqcrypto-hqc/src/hqcrmrs192.rs
@@ -113,67 +113,54 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_HQCRMRS192_CLEAN_CRYPTO_BYTES
 }
 
-/// Generate a hqc-rmrs-192 keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_HQCRMRS192_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
+/// Generate a hqc-rmrs-192 keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_HQCRMRS192_CLEAN_crypto_kem_keypair)
+}
+
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a hqc-rmrs-192 public key
 pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_HQCRMRS192_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_HQCRMRS192_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received hqc-rmrs-192 ciphertext
 pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_HQCRMRS192_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
+    decap!(PQCLEAN_HQCRMRS192_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-hqc/src/hqcrmrs256.rs
+++ b/pqcrypto-hqc/src/hqcrmrs256.rs
@@ -113,67 +113,54 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_HQCRMRS256_CLEAN_CRYPTO_BYTES
 }
 
-/// Generate a hqc-rmrs-256 keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_HQCRMRS256_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
+/// Generate a hqc-rmrs-256 keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_HQCRMRS256_CLEAN_crypto_kem_keypair)
+}
+
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a hqc-rmrs-256 public key
 pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_HQCRMRS256_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_HQCRMRS256_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received hqc-rmrs-256 ciphertext
 pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_HQCRMRS256_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
+    decap!(PQCLEAN_HQCRMRS256_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-kyber/src/kyber1024.rs
+++ b/pqcrypto-kyber/src/kyber1024.rs
@@ -113,40 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_KYBER1024_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a kyber1024 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_KYBER1024_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_KYBER1024_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER1024_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_KYBER1024_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a kyber1024 public key
@@ -154,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_KYBER1024_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_KYBER1024_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER1024_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_KYBER1024_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received kyber1024 ciphertext
@@ -204,38 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_KYBER1024_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER1024_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_KYBER1024_AVX2_crypto_kem_dec(ss.0.as_mut_ptr(), ct.0.as_ptr(), sk.0.as_ptr(),),
-        0
-    );
-    ss
+    decap!(PQCLEAN_KYBER1024_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-kyber/src/kyber102490s.rs
+++ b/pqcrypto-kyber/src/kyber102490s.rs
@@ -113,40 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_KYBER102490S_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a kyber1024-90s keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_KYBER102490S_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_KYBER102490S_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER102490S_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_KYBER102490S_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a kyber1024-90s public key
@@ -154,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_KYBER102490S_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_KYBER102490S_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER102490S_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_KYBER102490S_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received kyber1024-90s ciphertext
@@ -204,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_KYBER102490S_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER102490S_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_KYBER102490S_AVX2_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_KYBER102490S_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-kyber/src/kyber512.rs
+++ b/pqcrypto-kyber/src/kyber512.rs
@@ -107,40 +107,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_KYBER512_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a kyber512 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_KYBER512_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_KYBER512_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a kyber512 public key
@@ -148,49 +147,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_KYBER512_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_KYBER512_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER512_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_KYBER512_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received kyber512 ciphertext
@@ -198,38 +169,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_KYBER512_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER512_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_KYBER512_AVX2_crypto_kem_dec(ss.0.as_mut_ptr(), ct.0.as_ptr(), sk.0.as_ptr(),),
-        0
-    );
-    ss
+    decap!(PQCLEAN_KYBER512_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-kyber/src/kyber51290s.rs
+++ b/pqcrypto-kyber/src/kyber51290s.rs
@@ -113,40 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_KYBER51290S_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a kyber512-90s keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_KYBER51290S_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_KYBER51290S_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER51290S_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_KYBER51290S_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a kyber512-90s public key
@@ -154,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_KYBER51290S_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_KYBER51290S_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER51290S_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_KYBER51290S_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received kyber512-90s ciphertext
@@ -204,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_KYBER51290S_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER51290S_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_KYBER51290S_AVX2_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_KYBER51290S_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-kyber/src/kyber768.rs
+++ b/pqcrypto-kyber/src/kyber768.rs
@@ -107,40 +107,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_KYBER768_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a kyber768 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_KYBER768_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_KYBER768_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER768_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_KYBER768_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a kyber768 public key
@@ -148,49 +147,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_KYBER768_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_KYBER768_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER768_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_KYBER768_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received kyber768 ciphertext
@@ -198,38 +169,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_KYBER768_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER768_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_KYBER768_AVX2_crypto_kem_dec(ss.0.as_mut_ptr(), ct.0.as_ptr(), sk.0.as_ptr(),),
-        0
-    );
-    ss
+    decap!(PQCLEAN_KYBER768_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-kyber/src/kyber76890s.rs
+++ b/pqcrypto-kyber/src/kyber76890s.rs
@@ -113,40 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_KYBER76890S_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a kyber768-90s keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_KYBER76890S_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_KYBER76890S_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER76890S_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_KYBER76890S_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a kyber768-90s public key
@@ -154,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_KYBER76890S_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_KYBER76890S_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER76890S_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_KYBER76890S_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received kyber768-90s ciphertext
@@ -204,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_KYBER76890S_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_KYBER76890S_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_KYBER76890S_AVX2_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_KYBER76890S_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-ntru/src/ntruhps2048509.rs
+++ b/pqcrypto-ntru/src/ntruhps2048509.rs
@@ -113,43 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_NTRUHPS2048509_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a ntruhps2048509 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_NTRUHPS2048509_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_NTRUHPS2048509_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRUHPS2048509_CLEAN_crypto_kem_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_NTRUHPS2048509_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a ntruhps2048509 public key
@@ -157,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_NTRUHPS2048509_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_NTRUHPS2048509_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRUHPS2048509_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_NTRUHPS2048509_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received ntruhps2048509 ciphertext
@@ -207,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_NTRUHPS2048509_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRUHPS2048509_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_NTRUHPS2048509_AVX2_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_NTRUHPS2048509_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-ntru/src/ntruhps2048677.rs
+++ b/pqcrypto-ntru/src/ntruhps2048677.rs
@@ -113,43 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_NTRUHPS2048677_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a ntruhps2048677 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_NTRUHPS2048677_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_NTRUHPS2048677_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRUHPS2048677_CLEAN_crypto_kem_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_NTRUHPS2048677_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a ntruhps2048677 public key
@@ -157,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_NTRUHPS2048677_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_NTRUHPS2048677_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRUHPS2048677_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_NTRUHPS2048677_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received ntruhps2048677 ciphertext
@@ -207,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_NTRUHPS2048677_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRUHPS2048677_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_NTRUHPS2048677_AVX2_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_NTRUHPS2048677_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-ntru/src/ntruhps4096821.rs
+++ b/pqcrypto-ntru/src/ntruhps4096821.rs
@@ -113,43 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_NTRUHPS4096821_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a ntruhps4096821 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_NTRUHPS4096821_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_NTRUHPS4096821_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRUHPS4096821_CLEAN_crypto_kem_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_NTRUHPS4096821_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a ntruhps4096821 public key
@@ -157,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_NTRUHPS4096821_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_NTRUHPS4096821_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRUHPS4096821_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_NTRUHPS4096821_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received ntruhps4096821 ciphertext
@@ -207,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_NTRUHPS4096821_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRUHPS4096821_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_NTRUHPS4096821_AVX2_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_NTRUHPS4096821_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-ntru/src/ntruhrss701.rs
+++ b/pqcrypto-ntru/src/ntruhrss701.rs
@@ -113,40 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_NTRUHRSS701_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a ntruhrss701 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_NTRUHRSS701_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_NTRUHRSS701_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRUHRSS701_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_NTRUHRSS701_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a ntruhrss701 public key
@@ -154,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_NTRUHRSS701_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_NTRUHRSS701_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRUHRSS701_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_NTRUHRSS701_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received ntruhrss701 ciphertext
@@ -204,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_NTRUHRSS701_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRUHRSS701_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_NTRUHRSS701_AVX2_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_NTRUHRSS701_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-ntruprime/src/ntrulpr653.rs
+++ b/pqcrypto-ntruprime/src/ntrulpr653.rs
@@ -113,40 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_NTRULPR653_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a ntrulpr653 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_NTRULPR653_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_NTRULPR653_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRULPR653_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_NTRULPR653_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a ntrulpr653 public key
@@ -154,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_NTRULPR653_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_NTRULPR653_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRULPR653_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_NTRULPR653_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received ntrulpr653 ciphertext
@@ -204,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_NTRULPR653_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRULPR653_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_NTRULPR653_AVX2_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_NTRULPR653_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-ntruprime/src/ntrulpr761.rs
+++ b/pqcrypto-ntruprime/src/ntrulpr761.rs
@@ -113,40 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_NTRULPR761_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a ntrulpr761 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_NTRULPR761_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_NTRULPR761_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRULPR761_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_NTRULPR761_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a ntrulpr761 public key
@@ -154,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_NTRULPR761_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_NTRULPR761_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRULPR761_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_NTRULPR761_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received ntrulpr761 ciphertext
@@ -204,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_NTRULPR761_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRULPR761_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_NTRULPR761_AVX2_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_NTRULPR761_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-ntruprime/src/ntrulpr857.rs
+++ b/pqcrypto-ntruprime/src/ntrulpr857.rs
@@ -113,40 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_NTRULPR857_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a ntrulpr857 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_NTRULPR857_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_NTRULPR857_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRULPR857_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_NTRULPR857_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a ntrulpr857 public key
@@ -154,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_NTRULPR857_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_NTRULPR857_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRULPR857_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_NTRULPR857_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received ntrulpr857 ciphertext
@@ -204,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_NTRULPR857_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_NTRULPR857_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_NTRULPR857_AVX2_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_NTRULPR857_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-ntruprime/src/sntrup653.rs
+++ b/pqcrypto-ntruprime/src/sntrup653.rs
@@ -113,40 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_SNTRUP653_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sntrup653 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SNTRUP653_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SNTRUP653_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_SNTRUP653_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SNTRUP653_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a sntrup653 public key
@@ -154,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_SNTRUP653_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_SNTRUP653_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_SNTRUP653_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_SNTRUP653_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received sntrup653 ciphertext
@@ -204,38 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_SNTRUP653_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_SNTRUP653_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_SNTRUP653_AVX2_crypto_kem_dec(ss.0.as_mut_ptr(), ct.0.as_ptr(), sk.0.as_ptr(),),
-        0
-    );
-    ss
+    decap!(PQCLEAN_SNTRUP653_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-ntruprime/src/sntrup761.rs
+++ b/pqcrypto-ntruprime/src/sntrup761.rs
@@ -113,40 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_SNTRUP761_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sntrup761 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SNTRUP761_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SNTRUP761_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_SNTRUP761_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SNTRUP761_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a sntrup761 public key
@@ -154,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_SNTRUP761_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_SNTRUP761_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_SNTRUP761_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_SNTRUP761_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received sntrup761 ciphertext
@@ -204,38 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_SNTRUP761_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_SNTRUP761_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_SNTRUP761_AVX2_crypto_kem_dec(ss.0.as_mut_ptr(), ct.0.as_ptr(), sk.0.as_ptr(),),
-        0
-    );
-    ss
+    decap!(PQCLEAN_SNTRUP761_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-ntruprime/src/sntrup857.rs
+++ b/pqcrypto-ntruprime/src/sntrup857.rs
@@ -113,40 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_SNTRUP857_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sntrup857 keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SNTRUP857_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SNTRUP857_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_SNTRUP857_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SNTRUP857_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a sntrup857 public key
@@ -154,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_SNTRUP857_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_SNTRUP857_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_SNTRUP857_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_SNTRUP857_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received sntrup857 ciphertext
@@ -204,38 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_SNTRUP857_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_SNTRUP857_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_SNTRUP857_AVX2_crypto_kem_dec(ss.0.as_mut_ptr(), ct.0.as_ptr(), sk.0.as_ptr(),),
-        0
-    );
-    ss
+    decap!(PQCLEAN_SNTRUP857_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-rainbow/src/rainbowicircumzenithal.rs
+++ b/pqcrypto-rainbow/src/rainbowicircumzenithal.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_RAINBOWICIRCUMZENITHAL_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,101 +169,125 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_RAINBOWICIRCUMZENITHAL_CLEAN_CRYPTO_BYTES
 }
 
-/// Generate a rainbowI-circumzenithal keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+/// Generate a rainbowI-circumzenithal keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_RAINBOWICIRCUMZENITHAL_CLEAN_crypto_sign_keypair)
+}
+
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_RAINBOWICIRCUMZENITHAL_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
 pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_RAINBOWICIRCUMZENITHAL_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_RAINBOWICIRCUMZENITHAL_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
 ) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_RAINBOWICIRCUMZENITHAL_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_RAINBOWICIRCUMZENITHAL_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
 pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_RAINBOWICIRCUMZENITHAL_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_RAINBOWICIRCUMZENITHAL_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -271,28 +296,12 @@ pub fn verify_detached_signature(
     msg: &[u8],
     pk: &PublicKey,
 ) -> std::result::Result<(), primitive::VerificationError> {
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_RAINBOWICIRCUMZENITHAL_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_RAINBOWICIRCUMZENITHAL_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-rainbow/src/rainbowiclassic.rs
+++ b/pqcrypto-rainbow/src/rainbowiclassic.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_RAINBOWICLASSIC_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -165,101 +166,117 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_RAINBOWICLASSIC_CLEAN_CRYPTO_BYTES
 }
 
-/// Generate a rainbowI-classic keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+/// Generate a rainbowI-classic keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_RAINBOWICLASSIC_CLEAN_crypto_sign_keypair)
+}
+
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_RAINBOWICLASSIC_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
 pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_RAINBOWICLASSIC_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_RAINBOWICLASSIC_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
 ) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    open_portable(sm, pk)
+    open_signed!(PQCLEAN_RAINBOWICLASSIC_CLEAN_crypto_sign_open, sm, pk)
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_RAINBOWICLASSIC_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
 pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    detached_sign_portable(msg, sk)
+    detached_signature!(PQCLEAN_RAINBOWICLASSIC_CLEAN_crypto_sign_signature, msg, sk)
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_RAINBOWICLASSIC_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -268,28 +285,12 @@ pub fn verify_detached_signature(
     msg: &[u8],
     pk: &PublicKey,
 ) -> std::result::Result<(), primitive::VerificationError> {
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_RAINBOWICLASSIC_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_RAINBOWICLASSIC_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-rainbow/src/rainbowicompressed.rs
+++ b/pqcrypto-rainbow/src/rainbowicompressed.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_RAINBOWICOMPRESSED_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -165,101 +166,121 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_RAINBOWICOMPRESSED_CLEAN_CRYPTO_BYTES
 }
 
-/// Generate a rainbowI-compressed keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+/// Generate a rainbowI-compressed keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_RAINBOWICOMPRESSED_CLEAN_crypto_sign_keypair)
+}
+
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_RAINBOWICOMPRESSED_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
 pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_RAINBOWICOMPRESSED_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_RAINBOWICOMPRESSED_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
 ) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    open_portable(sm, pk)
+    open_signed!(PQCLEAN_RAINBOWICOMPRESSED_CLEAN_crypto_sign_open, sm, pk)
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_RAINBOWICOMPRESSED_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
 pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_RAINBOWICOMPRESSED_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_RAINBOWICOMPRESSED_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -268,28 +289,12 @@ pub fn verify_detached_signature(
     msg: &[u8],
     pk: &PublicKey,
 ) -> std::result::Result<(), primitive::VerificationError> {
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_RAINBOWICOMPRESSED_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_RAINBOWICOMPRESSED_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-rainbow/src/rainbowiiicircumzenithal.rs
+++ b/pqcrypto-rainbow/src/rainbowiiicircumzenithal.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_RAINBOWIIICIRCUMZENITHAL_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,101 +169,125 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_RAINBOWIIICIRCUMZENITHAL_CLEAN_CRYPTO_BYTES
 }
 
-/// Generate a rainbowIII-circumzenithal keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+/// Generate a rainbowIII-circumzenithal keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_RAINBOWIIICIRCUMZENITHAL_CLEAN_crypto_sign_keypair)
+}
+
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_RAINBOWIIICIRCUMZENITHAL_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
 pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_RAINBOWIIICIRCUMZENITHAL_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_RAINBOWIIICIRCUMZENITHAL_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
 ) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_RAINBOWIIICIRCUMZENITHAL_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_RAINBOWIIICIRCUMZENITHAL_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
 pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_RAINBOWIIICIRCUMZENITHAL_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_RAINBOWIIICIRCUMZENITHAL_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -271,28 +296,12 @@ pub fn verify_detached_signature(
     msg: &[u8],
     pk: &PublicKey,
 ) -> std::result::Result<(), primitive::VerificationError> {
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_RAINBOWIIICIRCUMZENITHAL_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_RAINBOWIIICIRCUMZENITHAL_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-rainbow/src/rainbowiiiclassic.rs
+++ b/pqcrypto-rainbow/src/rainbowiiiclassic.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_RAINBOWIIICLASSIC_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -165,101 +166,121 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_RAINBOWIIICLASSIC_CLEAN_CRYPTO_BYTES
 }
 
-/// Generate a rainbowIII-classic keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+/// Generate a rainbowIII-classic keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_RAINBOWIIICLASSIC_CLEAN_crypto_sign_keypair)
+}
+
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_RAINBOWIIICLASSIC_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
 pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_RAINBOWIIICLASSIC_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_RAINBOWIIICLASSIC_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
 ) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    open_portable(sm, pk)
+    open_signed!(PQCLEAN_RAINBOWIIICLASSIC_CLEAN_crypto_sign_open, sm, pk)
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_RAINBOWIIICLASSIC_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
 pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_RAINBOWIIICLASSIC_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_RAINBOWIIICLASSIC_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -268,28 +289,12 @@ pub fn verify_detached_signature(
     msg: &[u8],
     pk: &PublicKey,
 ) -> std::result::Result<(), primitive::VerificationError> {
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_RAINBOWIIICLASSIC_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_RAINBOWIIICLASSIC_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-rainbow/src/rainbowiiicompressed.rs
+++ b/pqcrypto-rainbow/src/rainbowiiicompressed.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_RAINBOWIIICOMPRESSED_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,101 +169,121 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_RAINBOWIIICOMPRESSED_CLEAN_CRYPTO_BYTES
 }
 
-/// Generate a rainbowIII-compressed keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+/// Generate a rainbowIII-compressed keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_RAINBOWIIICOMPRESSED_CLEAN_crypto_sign_keypair)
+}
+
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_RAINBOWIIICOMPRESSED_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
 pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_RAINBOWIIICOMPRESSED_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_RAINBOWIIICOMPRESSED_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
 ) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    open_portable(sm, pk)
+    open_signed!(PQCLEAN_RAINBOWIIICOMPRESSED_CLEAN_crypto_sign_open, sm, pk)
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_RAINBOWIIICOMPRESSED_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
 pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_RAINBOWIIICOMPRESSED_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_RAINBOWIIICOMPRESSED_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -271,28 +292,12 @@ pub fn verify_detached_signature(
     msg: &[u8],
     pk: &PublicKey,
 ) -> std::result::Result<(), primitive::VerificationError> {
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_RAINBOWIIICOMPRESSED_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_RAINBOWIIICOMPRESSED_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-rainbow/src/rainbowvcircumzenithal.rs
+++ b/pqcrypto-rainbow/src/rainbowvcircumzenithal.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_RAINBOWVCIRCUMZENITHAL_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,101 +169,125 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_RAINBOWVCIRCUMZENITHAL_CLEAN_CRYPTO_BYTES
 }
 
-/// Generate a rainbowV-circumzenithal keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+/// Generate a rainbowV-circumzenithal keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_RAINBOWVCIRCUMZENITHAL_CLEAN_crypto_sign_keypair)
+}
+
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_RAINBOWVCIRCUMZENITHAL_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
 pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_RAINBOWVCIRCUMZENITHAL_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_RAINBOWVCIRCUMZENITHAL_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
 ) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_RAINBOWVCIRCUMZENITHAL_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_RAINBOWVCIRCUMZENITHAL_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
 pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_RAINBOWVCIRCUMZENITHAL_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_RAINBOWVCIRCUMZENITHAL_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -271,28 +296,12 @@ pub fn verify_detached_signature(
     msg: &[u8],
     pk: &PublicKey,
 ) -> std::result::Result<(), primitive::VerificationError> {
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_RAINBOWVCIRCUMZENITHAL_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_RAINBOWVCIRCUMZENITHAL_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-rainbow/src/rainbowvclassic.rs
+++ b/pqcrypto-rainbow/src/rainbowvclassic.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_RAINBOWVCLASSIC_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -165,101 +166,117 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_RAINBOWVCLASSIC_CLEAN_CRYPTO_BYTES
 }
 
-/// Generate a rainbowV-classic keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+/// Generate a rainbowV-classic keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_RAINBOWVCLASSIC_CLEAN_crypto_sign_keypair)
+}
+
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_RAINBOWVCLASSIC_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
 pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_RAINBOWVCLASSIC_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_RAINBOWVCLASSIC_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
 ) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    open_portable(sm, pk)
+    open_signed!(PQCLEAN_RAINBOWVCLASSIC_CLEAN_crypto_sign_open, sm, pk)
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_RAINBOWVCLASSIC_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
 pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    detached_sign_portable(msg, sk)
+    detached_signature!(PQCLEAN_RAINBOWVCLASSIC_CLEAN_crypto_sign_signature, msg, sk)
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_RAINBOWVCLASSIC_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -268,28 +285,12 @@ pub fn verify_detached_signature(
     msg: &[u8],
     pk: &PublicKey,
 ) -> std::result::Result<(), primitive::VerificationError> {
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_RAINBOWVCLASSIC_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_RAINBOWVCLASSIC_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-rainbow/src/rainbowvcompressed.rs
+++ b/pqcrypto-rainbow/src/rainbowvcompressed.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_RAINBOWVCOMPRESSED_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -165,101 +166,121 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_RAINBOWVCOMPRESSED_CLEAN_CRYPTO_BYTES
 }
 
-/// Generate a rainbowV-compressed keypair
-pub fn keypair() -> (PublicKey, SecretKey) {
-    keypair_portable()
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+/// Generate a rainbowV-compressed keypair
+pub fn keypair() -> (PublicKey, SecretKey) {
+    gen_keypair!(PQCLEAN_RAINBOWVCOMPRESSED_CLEAN_crypto_sign_keypair)
+}
+
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_RAINBOWVCOMPRESSED_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
 pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_RAINBOWVCOMPRESSED_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_RAINBOWVCOMPRESSED_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
 ) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    open_portable(sm, pk)
+    open_signed!(PQCLEAN_RAINBOWVCOMPRESSED_CLEAN_crypto_sign_open, sm, pk)
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_RAINBOWVCOMPRESSED_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
 pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_RAINBOWVCOMPRESSED_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_RAINBOWVCOMPRESSED_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -268,28 +289,12 @@ pub fn verify_detached_signature(
     msg: &[u8],
     pk: &PublicKey,
 ) -> std::result::Result<(), primitive::VerificationError> {
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_RAINBOWVCOMPRESSED_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_RAINBOWVCOMPRESSED_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-saber/src/firesaber.rs
+++ b/pqcrypto-saber/src/firesaber.rs
@@ -113,40 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_FIRESABER_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a firesaber keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_FIRESABER_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_FIRESABER_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FIRESABER_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_FIRESABER_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a firesaber public key
@@ -154,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_FIRESABER_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_FIRESABER_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FIRESABER_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_FIRESABER_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received firesaber ciphertext
@@ -204,38 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_FIRESABER_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_FIRESABER_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_FIRESABER_AVX2_crypto_kem_dec(ss.0.as_mut_ptr(), ct.0.as_ptr(), sk.0.as_ptr(),),
-        0
-    );
-    ss
+    decap!(PQCLEAN_FIRESABER_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-saber/src/lightsaber.rs
+++ b/pqcrypto-saber/src/lightsaber.rs
@@ -113,40 +113,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_LIGHTSABER_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a lightsaber keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_LIGHTSABER_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_LIGHTSABER_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_LIGHTSABER_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_LIGHTSABER_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a lightsaber public key
@@ -154,49 +153,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_LIGHTSABER_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_LIGHTSABER_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_LIGHTSABER_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_LIGHTSABER_AVX2_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received lightsaber ciphertext
@@ -204,42 +175,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_LIGHTSABER_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_LIGHTSABER_CLEAN_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_LIGHTSABER_AVX2_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
+    decap!(PQCLEAN_LIGHTSABER_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-saber/src/saber.rs
+++ b/pqcrypto-saber/src/saber.rs
@@ -104,40 +104,39 @@ pub const fn shared_secret_bytes() -> usize {
     ffi::PQCLEAN_SABER_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a saber keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SABER_AVX2_crypto_kem_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SABER_CLEAN_crypto_kem_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_SABER_CLEAN_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SABER_AVX2_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        0
-    );
-    (pk, sk)
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {{
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }};
 }
 
 /// Encapsulate to a saber public key
@@ -145,45 +144,21 @@ pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_SABER_AVX2_crypto_kem_enc, pk);
         }
     }
-
-    encapsulate_portable(pk)
+    encap!(PQCLEAN_SABER_CLEAN_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_SABER_CLEAN_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_SABER_AVX2_crypto_kem_enc(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), pk.0.as_ptr(),),
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {{
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ss.0.as_mut_ptr(), $ct.0.as_ptr(), $sk.0.as_ptr(),) },
+            0
+        );
+        ss
+    }};
 }
 
 /// Decapsulate the received saber ciphertext
@@ -191,34 +166,10 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_SABER_AVX2_crypto_kem_dec, ct, sk);
         }
     }
-    decapsulate_portable(ct, sk)
-}
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_SABER_CLEAN_crypto_kem_dec(ss.0.as_mut_ptr(), ct.0.as_ptr(), sk.0.as_ptr())
-        },
-        0
-    );
-    ss
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_SABER_AVX2_crypto_kem_dec(ss.0.as_mut_ptr(), ct.0.as_ptr(), sk.0.as_ptr(),),
-        0
-    );
-    ss
+    decap!(PQCLEAN_SABER_CLEAN_crypto_kem_dec, ct, sk)
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsharaka128frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka128frobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-haraka-128f-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSHARAKA128FROBUST_AESNI_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSHARAKA128FROBUST_AESNI_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSHARAKA128FROBUST_AESNI_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSHARAKA128FROBUST_AESNI_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSHARAKA128FROBUST_AESNI_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSHARAKA128FROBUST_AESNI_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSHARAKA128FROBUST_AESNI_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSHARAKA128FROBUST_AESNI_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSHARAKA128FROBUST_AESNI_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSHARAKA128FROBUST_AESNI_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsharaka128fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka128fsimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-haraka-128f-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSHARAKA128FSIMPLE_AESNI_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSHARAKA128FSIMPLE_AESNI_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSHARAKA128FSIMPLE_AESNI_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSHARAKA128FSIMPLE_AESNI_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSHARAKA128FSIMPLE_AESNI_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSHARAKA128FSIMPLE_AESNI_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSHARAKA128FSIMPLE_AESNI_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSHARAKA128FSIMPLE_AESNI_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSHARAKA128FSIMPLE_AESNI_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSHARAKA128FSIMPLE_AESNI_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsharaka128srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka128srobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-haraka-128s-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSHARAKA128SROBUST_AESNI_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSHARAKA128SROBUST_AESNI_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSHARAKA128SROBUST_AESNI_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSHARAKA128SROBUST_AESNI_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSHARAKA128SROBUST_AESNI_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSHARAKA128SROBUST_AESNI_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSHARAKA128SROBUST_AESNI_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSHARAKA128SROBUST_AESNI_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSHARAKA128SROBUST_AESNI_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSHARAKA128SROBUST_AESNI_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsharaka128ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka128ssimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-haraka-128s-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSHARAKA128SSIMPLE_AESNI_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSHARAKA128SSIMPLE_AESNI_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSHARAKA128SSIMPLE_AESNI_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSHARAKA128SSIMPLE_AESNI_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSHARAKA128SSIMPLE_AESNI_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSHARAKA128SSIMPLE_AESNI_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSHARAKA128SSIMPLE_AESNI_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSHARAKA128SSIMPLE_AESNI_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSHARAKA128SSIMPLE_AESNI_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSHARAKA128SSIMPLE_AESNI_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsharaka192frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka192frobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-haraka-192f-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSHARAKA192FROBUST_AESNI_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSHARAKA192FROBUST_AESNI_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSHARAKA192FROBUST_AESNI_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSHARAKA192FROBUST_AESNI_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSHARAKA192FROBUST_AESNI_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSHARAKA192FROBUST_AESNI_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSHARAKA192FROBUST_AESNI_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSHARAKA192FROBUST_AESNI_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSHARAKA192FROBUST_AESNI_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSHARAKA192FROBUST_AESNI_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsharaka192fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka192fsimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-haraka-192f-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSHARAKA192FSIMPLE_AESNI_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSHARAKA192FSIMPLE_AESNI_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSHARAKA192FSIMPLE_AESNI_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSHARAKA192FSIMPLE_AESNI_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSHARAKA192FSIMPLE_AESNI_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSHARAKA192FSIMPLE_AESNI_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSHARAKA192FSIMPLE_AESNI_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSHARAKA192FSIMPLE_AESNI_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSHARAKA192FSIMPLE_AESNI_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSHARAKA192FSIMPLE_AESNI_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsharaka192srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka192srobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-haraka-192s-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSHARAKA192SROBUST_AESNI_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSHARAKA192SROBUST_AESNI_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSHARAKA192SROBUST_AESNI_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSHARAKA192SROBUST_AESNI_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSHARAKA192SROBUST_AESNI_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSHARAKA192SROBUST_AESNI_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSHARAKA192SROBUST_AESNI_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSHARAKA192SROBUST_AESNI_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSHARAKA192SROBUST_AESNI_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSHARAKA192SROBUST_AESNI_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsharaka192ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka192ssimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-haraka-192s-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSHARAKA192SSIMPLE_AESNI_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSHARAKA192SSIMPLE_AESNI_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSHARAKA192SSIMPLE_AESNI_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSHARAKA192SSIMPLE_AESNI_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSHARAKA192SSIMPLE_AESNI_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSHARAKA192SSIMPLE_AESNI_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSHARAKA192SSIMPLE_AESNI_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSHARAKA192SSIMPLE_AESNI_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSHARAKA192SSIMPLE_AESNI_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSHARAKA192SSIMPLE_AESNI_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsharaka256frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka256frobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-haraka-256f-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSHARAKA256FROBUST_AESNI_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSHARAKA256FROBUST_AESNI_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSHARAKA256FROBUST_AESNI_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSHARAKA256FROBUST_AESNI_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSHARAKA256FROBUST_AESNI_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSHARAKA256FROBUST_AESNI_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSHARAKA256FROBUST_AESNI_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSHARAKA256FROBUST_AESNI_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSHARAKA256FROBUST_AESNI_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSHARAKA256FROBUST_AESNI_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsharaka256fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka256fsimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-haraka-256f-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSHARAKA256FSIMPLE_AESNI_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSHARAKA256FSIMPLE_AESNI_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSHARAKA256FSIMPLE_AESNI_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSHARAKA256FSIMPLE_AESNI_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSHARAKA256FSIMPLE_AESNI_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSHARAKA256FSIMPLE_AESNI_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSHARAKA256FSIMPLE_AESNI_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSHARAKA256FSIMPLE_AESNI_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSHARAKA256FSIMPLE_AESNI_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSHARAKA256FSIMPLE_AESNI_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsharaka256srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka256srobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-haraka-256s-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSHARAKA256SROBUST_AESNI_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSHARAKA256SROBUST_AESNI_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSHARAKA256SROBUST_AESNI_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSHARAKA256SROBUST_AESNI_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSHARAKA256SROBUST_AESNI_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSHARAKA256SROBUST_AESNI_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSHARAKA256SROBUST_AESNI_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSHARAKA256SROBUST_AESNI_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSHARAKA256SROBUST_AESNI_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSHARAKA256SROBUST_AESNI_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsharaka256ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsharaka256ssimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-haraka-256s-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSHARAKA256SSIMPLE_AESNI_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSHARAKA256SSIMPLE_AESNI_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSHARAKA256SSIMPLE_AESNI_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSHARAKA256SSIMPLE_AESNI_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSHARAKA256SSIMPLE_AESNI_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSHARAKA256SSIMPLE_AESNI_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSHARAKA256SSIMPLE_AESNI_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSHARAKA256SSIMPLE_AESNI_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("aes") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSHARAKA256SSIMPLE_AESNI_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "aes")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSHARAKA256SSIMPLE_AESNI_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincssha256128frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256128frobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-sha256-128f-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincssha256128fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256128fsimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-sha256-128f-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincssha256128srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256128srobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-sha256-128s-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincssha256128ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256128ssimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-sha256-128s-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincssha256192frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256192frobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-sha256-192f-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincssha256192fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256192fsimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-sha256-192f-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincssha256192srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256192srobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-sha256-192s-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincssha256192ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256192ssimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-sha256-192s-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincssha256256frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256256frobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-sha256-256f-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincssha256256fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256256fsimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-sha256-256f-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincssha256256srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256256srobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-sha256-256s-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincssha256256ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincssha256256ssimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-sha256-256s-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsshake256128frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256128frobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-shake256-128f-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHAKE256128FROBUST_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHAKE256128FROBUST_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHAKE256128FROBUST_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHAKE256128FROBUST_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHAKE256128FROBUST_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHAKE256128FROBUST_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHAKE256128FROBUST_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHAKE256128FROBUST_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHAKE256128FROBUST_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHAKE256128FROBUST_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsshake256128fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256128fsimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-shake256-128f-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHAKE256128FSIMPLE_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHAKE256128FSIMPLE_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHAKE256128FSIMPLE_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHAKE256128FSIMPLE_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHAKE256128FSIMPLE_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHAKE256128FSIMPLE_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHAKE256128FSIMPLE_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHAKE256128FSIMPLE_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHAKE256128FSIMPLE_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHAKE256128FSIMPLE_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsshake256128srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256128srobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-shake256-128s-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHAKE256128SROBUST_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHAKE256128SROBUST_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHAKE256128SROBUST_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHAKE256128SROBUST_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHAKE256128SROBUST_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHAKE256128SROBUST_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHAKE256128SROBUST_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHAKE256128SROBUST_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHAKE256128SROBUST_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHAKE256128SROBUST_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsshake256128ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256128ssimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-shake256-128s-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHAKE256128SSIMPLE_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHAKE256128SSIMPLE_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHAKE256128SSIMPLE_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHAKE256128SSIMPLE_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHAKE256128SSIMPLE_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHAKE256128SSIMPLE_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHAKE256128SSIMPLE_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHAKE256128SSIMPLE_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHAKE256128SSIMPLE_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHAKE256128SSIMPLE_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsshake256192frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256192frobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-shake256-192f-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHAKE256192FROBUST_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHAKE256192FROBUST_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHAKE256192FROBUST_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHAKE256192FROBUST_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHAKE256192FROBUST_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHAKE256192FROBUST_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHAKE256192FROBUST_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHAKE256192FROBUST_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHAKE256192FROBUST_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHAKE256192FROBUST_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsshake256192fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256192fsimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-shake256-192f-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHAKE256192FSIMPLE_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHAKE256192FSIMPLE_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHAKE256192FSIMPLE_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHAKE256192FSIMPLE_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHAKE256192FSIMPLE_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHAKE256192FSIMPLE_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHAKE256192FSIMPLE_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHAKE256192FSIMPLE_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHAKE256192FSIMPLE_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHAKE256192FSIMPLE_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsshake256192srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256192srobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-shake256-192s-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHAKE256192SROBUST_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHAKE256192SROBUST_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHAKE256192SROBUST_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHAKE256192SROBUST_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHAKE256192SROBUST_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHAKE256192SROBUST_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHAKE256192SROBUST_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHAKE256192SROBUST_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHAKE256192SROBUST_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHAKE256192SROBUST_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsshake256192ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256192ssimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-shake256-192s-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHAKE256192SSIMPLE_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHAKE256192SSIMPLE_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHAKE256192SSIMPLE_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHAKE256192SSIMPLE_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHAKE256192SSIMPLE_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHAKE256192SSIMPLE_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHAKE256192SSIMPLE_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHAKE256192SSIMPLE_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHAKE256192SSIMPLE_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHAKE256192SSIMPLE_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsshake256256frobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256256frobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-shake256-256f-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHAKE256256FROBUST_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHAKE256256FROBUST_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHAKE256256FROBUST_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHAKE256256FROBUST_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHAKE256256FROBUST_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHAKE256256FROBUST_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHAKE256256FROBUST_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHAKE256256FROBUST_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHAKE256256FROBUST_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHAKE256256FROBUST_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsshake256256fsimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256256fsimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-shake256-256f-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHAKE256256FSIMPLE_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHAKE256256FSIMPLE_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHAKE256256FSIMPLE_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHAKE256256FSIMPLE_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHAKE256256FSIMPLE_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHAKE256256FSIMPLE_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHAKE256256FSIMPLE_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHAKE256256FSIMPLE_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHAKE256256FSIMPLE_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHAKE256256FSIMPLE_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsshake256256srobust.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256256srobust.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-shake256-256s-robust keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHAKE256256SROBUST_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHAKE256256SROBUST_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHAKE256256SROBUST_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHAKE256256SROBUST_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHAKE256256SROBUST_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHAKE256256SROBUST_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHAKE256256SROBUST_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHAKE256256SROBUST_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHAKE256256SROBUST_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHAKE256256SROBUST_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-sphincsplus/src/sphincsshake256256ssimple.rs
+++ b/pqcrypto-sphincsplus/src/sphincsshake256256ssimple.rs
@@ -88,6 +88,7 @@ simple_struct!(
     SecretKey,
     ffi::PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_CRYPTO_SECRETKEYBYTES
 );
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
@@ -168,46 +169,47 @@ pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_CRYPTO_BYTES
 }
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {{
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }};
+}
+
 /// Generate a sphincs-shake256-256s-simple keypair
 pub fn keypair() -> (PublicKey, SecretKey) {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { keypair_avx2() };
+            return gen_keypair!(PQCLEAN_SPHINCSSHAKE256256SSIMPLE_AVX2_crypto_sign_keypair);
         }
     }
-    keypair_portable()
+    gen_keypair!(PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_crypto_sign_keypair)
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
         unsafe {
-            ffi::PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_crypto_sign_keypair(
-                pk.0.as_mut_ptr(),
-                sk.0.as_mut_ptr(),
-            )
-        },
-        0
-    );
-    (pk, sk)
-}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        ffi::PQCLEAN_SPHINCSSHAKE256256SSIMPLE_AVX2_crypto_sign_keypair(
-            pk.0.as_mut_ptr(),
-            sk.0.as_mut_ptr()
-        ),
-        0
-    );
-    (pk, sk)
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }};
 }
 
 /// Sign the message and return the signed message.
@@ -215,52 +217,36 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_SPHINCSSHAKE256256SSIMPLE_AVX2_crypto_sign, msg, sk);
         }
     }
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_crypto_sign(
-            signed_msg.as_mut_ptr(),
-            &mut smlen as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
-    }
-    SignedMessage(signed_msg)
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {{
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_SPHINCSSHAKE256256SSIMPLE_AVX2_crypto_sign(
-        signed_msg.as_mut_ptr(),
-        &mut smlen as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-
+/// Open the signed message and if verification succeeds return the message
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey,
@@ -268,60 +254,34 @@ pub fn open(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(
+                PQCLEAN_SPHINCSSHAKE256256SSIMPLE_AVX2_crypto_sign_open,
+                sm,
+                pk
+            );
         }
     }
-    open_portable(sm, pk)
+    open_signed!(
+        PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_crypto_sign_open,
+        sm,
+        pk
+    )
 }
 
-#[inline]
-fn open_portable(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_crypto_sign_open(
-            m.as_mut_ptr(),
-            &mut mlen as *mut usize,
-            sm.0.as_ptr(),
-            sm.len(),
-            pk.0.as_ptr(),
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {{
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
         }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn open_avx2(
-    sm: &SignedMessage,
-    pk: &PublicKey,
-) -> std::result::Result<Vec<u8>, primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_SPHINCSSHAKE256256SSIMPLE_AVX2_crypto_sign_open(
-        m.as_mut_ptr(),
-        &mut mlen as *mut usize,
-        sm.0.as_ptr(),
-        sm.len(),
-        pk.0.as_ptr(),
-    ) {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        }
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+        sig
+    }};
 }
 
 /// Create a detached signature on the message
@@ -329,41 +289,37 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(
+                PQCLEAN_SPHINCSSHAKE256256SSIMPLE_AVX2_crypto_sign_signature,
+                msg,
+                sk
+            );
         }
     }
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(
+        PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_crypto_sign_signature,
+        msg,
+        sk
+    )
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_crypto_sign_signature(
-            sig.0.as_mut_ptr(),
-            &mut sig.1 as *mut usize,
-            msg.as_ptr(),
-            msg.len(),
-            sk.0.as_ptr(),
-        );
-    }
-    sig
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_SPHINCSSHAKE256256SSIMPLE_AVX2_crypto_sign_signature(
-        sig.0.as_mut_ptr(),
-        &mut sig.1 as *mut usize,
-        msg.as_ptr(),
-        msg.len(),
-        sk.0.as_ptr(),
-    );
-    sig
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {{
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }};
 }
 
 /// Verify the detached signature
@@ -375,54 +331,20 @@ pub fn verify_detached_signature(
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("avx2") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(
+                PQCLEAN_SPHINCSSHAKE256256SSIMPLE_AVX2_crypto_sign_verify,
+                sig,
+                msg,
+                pk
+            );
         }
     }
-
-    verify_detached_signature_portable(sig, msg, pk)
-}
-
-fn verify_detached_signature_portable(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr(),
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-#[cfg(enable_avx2)]
-#[target_feature(enable = "avx2")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(
-    sig: &DetachedSignature,
-    msg: &[u8],
-    pk: &PublicKey,
-) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_SPHINCSSHAKE256256SSIMPLE_AVX2_crypto_sign_verify(
-        sig.0.as_ptr(),
-        sig.1,
-        msg.as_ptr(),
-        msg.len(),
-        pk.0.as_ptr(),
-    );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
+    verify_detached_sig!(
+        PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_crypto_sign_verify,
+        sig,
+        msg,
+        pk
+    )
 }
 
 #[cfg(test)]

--- a/pqcrypto-template/pqcrypto/README.md.j2
+++ b/pqcrypto-template/pqcrypto/README.md.j2
@@ -5,6 +5,7 @@ the [NIST PQC standardization effort][nistpqc]. It is currently a collection of
 wrappers around C implementations from the [PQClean][pqclean] project.
 
 ## Insecure algorithms
+
 This crate contains optional support for insecure algorithms. They can be enabled via the
 ``cryptographically-insecure`` flag.
 
@@ -12,6 +13,7 @@ This crate also contains algorithms that have non-constant time implementations.
 Always check the relevant algorithms for their security details.
 
 ## Included algorithms
+
 This super-crate contains the following cryptographic algorithms:
 
 ## Key-Encapsulation Mechanisms
@@ -22,6 +24,7 @@ This super-crate contains the following cryptographic algorithms:
 {% endfor %}
 
 ## Signature Schemes
+
 {% for (name, props) in signs.items()|list %}
 * [``pqcrypto-{{ name }}``](https://crates.io/crates/pqcrypto-{{name}}) {% if props.insecure|default(False) %}(insecure, disabled by default){% endif %}
 
@@ -39,7 +42,6 @@ MIT or Apache 2.0 licenses, at your choice.
 
 The implementations we link to are not, however. Please see the [PQClean][pqclean]
 project for the appropriate licenses.
-
 
 [pqclean]: https://github.com/PQClean/PQClean/
 [nistpqc]: https://nist.gov/pqc/

--- a/pqcrypto-template/scheme/src/scheme.rs.j2
+++ b/pqcrypto-template/scheme/src/scheme.rs.j2
@@ -108,11 +108,12 @@ simple_struct!(
 );
 simple_struct!(SharedSecret, ffi::PQCLEAN_{{ NS_NAME }}_CRYPTO_BYTES);
 {% else %}
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DetachedSignature(
     #[cfg_attr(feature = "serialization", serde(with = "BigArray"))]
-    [u8; ffi::PQCLEAN_{{ NS_NAME }}_CRYPTO_BYTES], 
+    [u8; ffi::PQCLEAN_{{ NS_NAME }}_CRYPTO_BYTES],
     usize
 );
 
@@ -147,7 +148,6 @@ impl primitive::DetachedSignature for DetachedSignature {
         Ok(DetachedSignature(array, actual))
     }
 }
-
 
 #[derive(Clone)]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
@@ -200,114 +200,96 @@ pub const fn signature_bytes() -> usize {
 }
 {% endif %}
 
+macro_rules! gen_keypair {
+    ($variant:ident) => {
+    {
+        let mut pk = PublicKey::new();
+        let mut sk = SecretKey::new();
+        assert_eq!(
+            unsafe { ffi::$variant(pk.0.as_mut_ptr(),sk.0.as_mut_ptr()) },
+            0
+        );
+        (pk, sk)
+    }
+    };
+}
+
 /// Generate a {{ scheme.name }} keypair
 {% if insecure %}
 #[deprecated(note = "Insecure cryptography, do not use in production")]
 {% endif %}
 pub fn keypair() -> (PublicKey, SecretKey) {
-{% if 'avx2_implementation' in scheme %}
+    {% if 'avx2_implementation' in scheme %}
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
-            return unsafe { keypair_avx2() };
+            {% if type == "kem" %}
+            return gen_keypair!(PQCLEAN_{{ AVX2_NAME }}_crypto_kem_keypair);
+            {% else %}
+            return gen_keypair!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign_keypair);
+            {% endif %}
         }
     }
-{% endif %}
-    keypair_portable()
+    {% endif %}
+    {% if type == "kem" %}
+    gen_keypair!(PQCLEAN_{{ NS_NAME }}_crypto_kem_keypair)
+    {% else %}
+    gen_keypair!(PQCLEAN_{{ NS_NAME }}_crypto_sign_keypair)
+    {% endif %}
 }
 
-#[inline]
-fn keypair_portable() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        unsafe {
-            {% if type == "kem" %}
-            ffi::PQCLEAN_{{ NS_NAME }}_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-            {% else %}
-            ffi::PQCLEAN_{{ NS_NAME }}_crypto_sign_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr())
-            {% endif %}
-        },
-        0
-    );
-    (pk, sk)
-}
-{% if 'avx2_implementation' in scheme %}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "{{ scheme.avx2_feature }}")]
-#[inline]
-unsafe fn keypair_avx2() -> (PublicKey, SecretKey) {
-    let mut pk = PublicKey::new();
-    let mut sk = SecretKey::new();
-    assert_eq!(
-        {% if type == "kem" %}
-        ffi::PQCLEAN_{{ AVX2_NAME }}_crypto_kem_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        {% else %}
-        ffi::PQCLEAN_{{ AVX2_NAME }}_crypto_sign_keypair(pk.0.as_mut_ptr(), sk.0.as_mut_ptr()),
-        {% endif %}
-        0
-    );
-    (pk, sk)
-}
-{% endif %}
 
 {% if type == "kem" %}
+
+
+macro_rules! encap {
+    ($variant:ident, $pk:ident) => {
+    {
+        let mut ss = SharedSecret::new();
+        let mut ct = Ciphertext::new();
+        assert_eq!(
+            unsafe { ffi::$variant(ct.0.as_mut_ptr(), ss.0.as_mut_ptr(), $pk.0.as_ptr()) },
+            0,
+        );
+        (ss, ct)
+    }
+    };
+}
+
 /// Encapsulate to a {{ scheme.name }} public key
 {% if insecure %}
 #[deprecated(note = "Insecure cryptography, do not use in production")]
 {% endif %}
 pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-{% if 'avx2_implementation' in scheme %}
+    {% if 'avx2_implementation' in scheme %}
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
-            return unsafe { encapsulate_avx2(pk) };
+            return encap!(PQCLEAN_{{ AVX2_NAME }}_crypto_kem_enc, pk);
         }
     }
-{% endif %}
-
-    encapsulate_portable(pk)
+    {% endif %}
+    encap!(PQCLEAN_{{ NS_NAME }}_crypto_kem_enc, pk)
 }
 
-#[inline]
-fn encapsulate_portable(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_{{ NS_NAME }}_crypto_kem_enc(
-                ct.0.as_mut_ptr(),
-                ss.0.as_mut_ptr(),
-                pk.0.as_ptr(),
-            )
-        },
-        0,
-    );
-
-    (ss, ct)
+macro_rules! decap {
+    ($variant:ident, $ct:ident, $sk:ident) => {
+    {
+        let mut ss = SharedSecret::new();
+        assert_eq!(
+            unsafe {
+                ffi::$variant(
+                    ss.0.as_mut_ptr(),
+                    $ct.0.as_ptr(),
+                    $sk.0.as_ptr(),
+                )
+            },
+            0
+        );
+        ss
+    }
+    };
 }
-
-{% if 'avx2_implementation' in scheme %}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "{{ scheme.avx2_feature }}")]
-#[inline]
-unsafe fn encapsulate_avx2(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    let mut ss = SharedSecret::new();
-    let mut ct = Ciphertext::new();
-
-    assert_eq!(
-        ffi::PQCLEAN_{{ AVX2_NAME }}_crypto_kem_enc(
-            ct.0.as_mut_ptr(),
-            ss.0.as_mut_ptr(),
-            pk.0.as_ptr(),
-        ),
-        0,
-    );
-
-    (ss, ct)
-}
-{% endif %}
 
 /// Decapsulate the received {{ scheme.name }} ciphertext
 {% if insecure %}
@@ -318,49 +300,38 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
-            return unsafe { decapsulate_avx2(ct, sk) };
+            return decap!(PQCLEAN_{{ AVX2_NAME }}_crypto_kem_dec, ct, sk);
         }
     }
     {% endif %}
-    decapsulate_portable(ct, sk)
+    decap!(PQCLEAN_{{ NS_NAME }}_crypto_kem_dec, ct, sk)
 }
-
-#[inline]
-fn decapsulate_portable(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        unsafe {
-            ffi::PQCLEAN_{{ NS_NAME }}_crypto_kem_dec(
-                ss.0.as_mut_ptr(),
-                ct.0.as_ptr(),
-                sk.0.as_ptr(),
-            )
-        },
-        0
-    );
-    ss
-}
-
-{% if 'avx2_implementation' in scheme %}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "{{ scheme.avx2_feature }}")]
-#[inline]
-unsafe fn decapsulate_avx2(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    let mut ss = SharedSecret::new();
-    assert_eq!(
-        ffi::PQCLEAN_{{ AVX2_NAME }}_crypto_kem_dec(
-            ss.0.as_mut_ptr(),
-            ct.0.as_ptr(),
-            sk.0.as_ptr(),
-        ),
-        0
-    );
-    ss
-}
-{% endif %}
 
 
 {% else %}
+
+
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {
+    {
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
+        unsafe {
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }
+    };
+}
 
 /// Sign the message and return the signed message.
 {% if insecure %}
@@ -371,108 +342,74 @@ pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
-            return unsafe { sign_avx2(msg, sk) };
+            return gen_signature!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign, msg, sk);
         }
     }
     {% endif %}
-
-    sign_portable(msg, sk)
+    gen_signature!(PQCLEAN_{{ NS_NAME }}_crypto_sign, msg, sk)
 }
 
-#[inline]
-fn sign_portable(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    unsafe {
-        ffi::PQCLEAN_{{ NS_NAME }}_crypto_sign(
-            signed_msg.as_mut_ptr(), &mut smlen as *mut usize,
-            msg.as_ptr(), msg.len(),
-            sk.0.as_ptr()
-        );
-        debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-        signed_msg.set_len(smlen);
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {
+    {
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
     }
-    SignedMessage(signed_msg)
+    };
 }
 
-{% if 'avx2_implementation' in scheme %}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "{{ scheme.avx2_feature }}")]
-#[inline]
-unsafe fn sign_avx2(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    let max_len = msg.len() + signature_bytes();
-    let mut signed_msg = Vec::with_capacity(max_len);
-    let mut smlen: usize = 0;
-    ffi::PQCLEAN_{{ AVX2_NAME }}_crypto_sign(
-        signed_msg.as_mut_ptr(), &mut smlen as *mut usize,
-        msg.as_ptr(), msg.len(),
-        sk.0.as_ptr()
-    );
-    debug_assert!(smlen <= max_len, "exceeded Vec capacity");
-    signed_msg.set_len(smlen);
-
-    SignedMessage(signed_msg)
-}
-{% endif %}
-
+/// Open the signed message and if verification succeeds return the message
 {% if insecure %}
 #[deprecated(note = "Insecure cryptography, do not use in production")]
 {% endif %}
-pub fn open(sm: &SignedMessage, pk: &PublicKey) -> std::result::Result<Vec<u8>,primitive::VerificationError> {
+pub fn open(
+    sm: &SignedMessage,
+    pk: &PublicKey
+) -> std::result::Result<Vec<u8>,primitive::VerificationError> {
     {% if 'avx2_implementation' in scheme %}
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
-            return unsafe { open_avx2(sm, pk) };
+            return open_signed!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign_open, sm, pk);
         }
     }
     {% endif %}
-    open_portable(sm, pk)
+    open_signed!(PQCLEAN_{{ NS_NAME }}_crypto_sign_open, sm, pk)
 }
 
-#[inline]
-fn open_portable(sm: &SignedMessage, pk: &PublicKey) -> std::result::Result<Vec<u8>,primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match unsafe {
-        ffi::PQCLEAN_{{ NS_NAME }}_crypto_sign_open(
-            m.as_mut_ptr(), &mut mlen as *mut usize,
-            sm.0.as_ptr(), sm.len(),
-            pk.0.as_ptr()
-        )
-    } {
-        0 => {
-            unsafe { m.set_len(mlen) };
-            Ok(m)
-        },
-          -1 => Err(primitive::VerificationError::InvalidSignature),
-          _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
-
-{% if 'avx2_implementation' in scheme %}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "{{ scheme.avx2_feature }}")]
-#[inline]
-unsafe fn open_avx2(sm: &SignedMessage, pk: &PublicKey) -> std::result::Result<Vec<u8>,primitive::VerificationError> {
-    let mut m: Vec<u8> = Vec::with_capacity(sm.len());
-    let mut mlen: usize = 0;
-    match ffi::PQCLEAN_{{ AVX2_NAME }}_crypto_sign_open(
-            m.as_mut_ptr(), &mut mlen as *mut usize,
-            sm.0.as_ptr(), sm.len(),
-            pk.0.as_ptr()
-        )
+macro_rules! detached_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {
     {
-        0 => {
-            m.set_len(mlen);
-            Ok(m)
-        },
-          -1 => Err(primitive::VerificationError::InvalidSignature),
-          _ => Err(primitive::VerificationError::UnknownVerificationError),
+        let mut sig = DetachedSignature::new();
+        unsafe {
+            ffi::$variant(
+                sig.0.as_mut_ptr(),
+                &mut sig.1 as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+        }
+        sig
     }
+    };
 }
-{% endif %}
 
 {% if insecure %}
 #[deprecated(note = "Insecure cryptography, do not use in production")]
@@ -483,41 +420,33 @@ pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
-            return unsafe { detached_sign_avx2(msg, sk) };
+            return detached_signature!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign_signature, msg, sk);
         }
     }
     {% endif %}
-
-    detached_sign_portable(msg, sk)
+    detached_signature!(PQCLEAN_{{ NS_NAME }}_crypto_sign_signature, msg, sk)
 }
 
-#[inline]
-fn detached_sign_portable(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    unsafe {
-        ffi::PQCLEAN_{{ NS_NAME }}_crypto_sign_signature(
-            sig.0.as_mut_ptr(), &mut sig.1 as *mut usize,
-            msg.as_ptr(), msg.len(),
-            sk.0.as_ptr()
-        );
+macro_rules! verify_detached_sig {
+    ($variant:ident, $sig:ident, $msg:ident, $pk:ident) => {
+    {
+        let res = unsafe {
+            ffi::$variant(
+                $sig.0.as_ptr(),
+                $sig.1,
+                $msg.as_ptr(),
+                $msg.len(),
+                $pk.0.as_ptr(),
+            )
+        };
+        match res {
+            0 => Ok(()),
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
     }
-    sig
+    };
 }
-
-{% if 'avx2_implementation' in scheme %}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "{{ scheme.avx2_feature }}")]
-#[inline]
-unsafe fn detached_sign_avx2(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    let mut sig = DetachedSignature::new();
-    ffi::PQCLEAN_{{ AVX2_NAME }}_crypto_sign_signature(
-        sig.0.as_mut_ptr(), &mut sig.1 as *mut usize,
-        msg.as_ptr(), msg.len(),
-        sk.0.as_ptr()
-    );
-    sig
-}
-{% endif %}
 
 /// Verify the detached signature
 {% if insecure %}
@@ -528,51 +457,16 @@ pub fn verify_detached_signature(sig: &DetachedSignature, msg: &[u8], pk: &Publi
     #[cfg(enable_avx2)]
     {
         if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
-            return unsafe { verify_detached_signature_avx2(sig, msg, pk) };
+            return verify_detached_sig!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign_verify, sig, msg, pk);
         }
     }
     {% endif %}
-
-    verify_detached_signature_portable(sig, msg, pk)
+    verify_detached_sig!(PQCLEAN_{{ NS_NAME }}_crypto_sign_verify, sig, msg, pk)
 }
 
-fn verify_detached_signature_portable(sig: &DetachedSignature, msg: &[u8], pk: &PublicKey) -> std::result::Result<(), primitive::VerificationError> {
-    let res = unsafe {
-        ffi::PQCLEAN_{{ NS_NAME }}_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr()
-        )
-    };
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
 
-{% if 'avx2_implementation' in scheme %}
-#[cfg(enable_avx2)]
-#[target_feature(enable = "{{ scheme.avx2_feature }}")]
-#[inline]
-unsafe fn verify_detached_signature_avx2(sig: &DetachedSignature, msg: &[u8], pk: &PublicKey) -> std::result::Result<(), primitive::VerificationError> {
-    let res = ffi::PQCLEAN_{{ AVX2_NAME }}_crypto_sign_verify(
-            sig.0.as_ptr(),
-            sig.1,
-            msg.as_ptr(),
-            msg.len(),
-            pk.0.as_ptr()
-        );
-    match res {
-        0 => Ok(()),
-        -1 => Err(primitive::VerificationError::InvalidSignature),
-        _ => Err(primitive::VerificationError::UnknownVerificationError),
-    }
-}
 {% endif %}
-{% endif %}
+
 
 #[cfg(test)]
 mod test {

--- a/pqcrypto/README.md
+++ b/pqcrypto/README.md
@@ -5,6 +5,7 @@ the [NIST PQC standardization effort][nistpqc]. It is currently a collection of
 wrappers around C implementations from the [PQClean][pqclean] project.
 
 ## Insecure algorithms
+
 This crate contains optional support for insecure algorithms. They can be enabled via the
 ``cryptographically-insecure`` flag.
 
@@ -12,6 +13,7 @@ This crate also contains algorithms that have non-constant time implementations.
 Always check the relevant algorithms for their security details.
 
 ## Included algorithms
+
 This super-crate contains the following cryptographic algorithms:
 
 ## Key-Encapsulation Mechanisms
@@ -25,6 +27,7 @@ This super-crate contains the following cryptographic algorithms:
 * [``pqcrypto-hqc``](https://crates.io/crates/pqcrypto-hqc)
 
 ## Signature Schemes
+
 * [``pqcrypto-dilithium``](https://crates.io/crates/pqcrypto-dilithium)
 * [``pqcrypto-falcon``](https://crates.io/crates/pqcrypto-falcon)
 * [``pqcrypto-rainbow``](https://crates.io/crates/pqcrypto-rainbow)
@@ -42,7 +45,6 @@ MIT or Apache 2.0 licenses, at your choice.
 
 The implementations we link to are not, however. Please see the [PQClean][pqclean]
 project for the appropriate licenses.
-
 
 [pqclean]: https://github.com/PQClean/PQClean/
 [nistpqc]: https://nist.gov/pqc/


### PR DESCRIPTION
Hi Thom,
nice to see the update from PQClean and the Serde addition.
This PR changes the different methods (keypair_xxx(), encapsulate_xxx(), ...) to a macro based approach.
Therefore less code needs to be maintained and support for possible NEON implementations can be added easily in the future.
All schemes are tested and no functionality change (API) should be visible.

Best regards,
Robin