### PR TITLE
Made pqcrypto no-std compatible

### DIFF
--- a/pqcrypto-template/scheme/Cargo.toml.j2
+++ b/pqcrypto-template/scheme/Cargo.toml.j2
@@ -12,18 +12,19 @@ keywords = ["cryptography", "post-quantum", "security"]
 categories = ["cryptography"]
 
 [dependencies]
-pqcrypto-traits = {path = "../pqcrypto-traits", version = "{{ traits_version }}"}
+pqcrypto-traits = {path = "../pqcrypto-traits", version = "{{ traits_version }}", default-features = false}
 libc = "0.2.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde-big-array = { version = "0.3.2", features = ["const-generics"], optional = true }
 
 [features]
 {% if has_avx2 %}
-default = ["avx2"]
+default = ["avx2", "std"]
 avx2 = []
 {% else %}
-default = []
+default = ["std"]
 {% endif %}
+std = ["pqcrypto-traits/std"]
 serialization = ["serde", "serde-big-array"]
 {% if insecure %}
 cryptographically-insecure = []

--- a/pqcrypto-template/scheme/Cargo.toml.j2
+++ b/pqcrypto-template/scheme/Cargo.toml.j2
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 homepage = "https://github.com/rustpq/"
 repository = "https://github.com/rustpq/pqcrypto/"
 keywords = ["cryptography", "post-quantum", "security"]
-categories = ["cryptography"]
+categories = ["cryptography", "no-std"]
 
 [dependencies]
 pqcrypto-traits = {path = "../pqcrypto-traits", version = "{{ traits_version }}", default-features = false}

--- a/pqcrypto-template/scheme/Cargo.toml.j2
+++ b/pqcrypto-template/scheme/Cargo.toml.j2
@@ -20,7 +20,7 @@ serde-big-array = { version = "0.3.2", features = ["const-generics"], optional =
 [features]
 {% if has_avx2 %}
 default = ["avx2", "std"]
-avx2 = []
+avx2 = ["std"]
 {% else %}
 default = ["std"]
 {% endif %}

--- a/pqcrypto-template/scheme/src/ffi.rs.j2
+++ b/pqcrypto-template/scheme/src/ffi.rs.j2
@@ -188,8 +188,9 @@ extern "C" {
 #[cfg(test)]
 mod test_{{ scheme.name|nameize }}_{{ implementation|nameize }} {
     use super::*;
+    use alloc::vec;
 {% if type == "sign" %}
-    use std::vec::Vec;
+    use alloc::vec::Vec;
     use rand::prelude::*;
 {% endif %}
 
@@ -313,12 +314,13 @@ mod test_{{ scheme.name|nameize }}_{{ implementation|nameize }} {
 {% if 'avx2_implementation' in scheme %}
 {% set implementation = scheme.avx2_implementation %}
 {% set NS_NAME = [scheme.name|namespaceize, implementation|namespaceize]|join('_') %}
-#[cfg(test)]
-#[cfg(enable_avx2)]
+#[cfg(all(test, enable_avx2, feature = "avx2"))]
 mod test_{{ scheme.name|nameize }}_{{ implementation|nameize }} {
     use super::*;
-    use std::{is_x86_feature_detected, vec::Vec};
+    use alloc::vec;
+    use std::is_x86_feature_detected;
 {% if type == "sign" %}
+    use alloc::vec::Vec;
     use rand::prelude::*;
 {% endif %}
 

--- a/pqcrypto-template/scheme/src/ffi.rs.j2
+++ b/pqcrypto-template/scheme/src/ffi.rs.j2
@@ -189,6 +189,7 @@ extern "C" {
 mod test_{{ scheme.name|nameize }}_{{ implementation|nameize }} {
     use super::*;
 {% if type == "sign" %}
+    use std::vec::Vec;
     use rand::prelude::*;
 {% endif %}
 
@@ -316,6 +317,7 @@ mod test_{{ scheme.name|nameize }}_{{ implementation|nameize }} {
 #[cfg(enable_avx2)]
 mod test_{{ scheme.name|nameize }}_{{ implementation|nameize }} {
     use super::*;
+    use std::{is_x86_feature_detected, vec::Vec};
 {% if type == "sign" %}
     use rand::prelude::*;
 {% endif %}

--- a/pqcrypto-template/scheme/src/lib.rs.j2
+++ b/pqcrypto-template/scheme/src/lib.rs.j2
@@ -17,8 +17,12 @@
 #![no_std]
 #![allow(clippy::len_without_is_empty)]
 
+// For no-std vectors
+extern crate alloc;
+
+// For tests
 #[cfg(feature = "std")]
-#[macro_use] extern crate std;
+extern crate std;
 
 {% if insecure %}
 #![cfg_attr(not(feature = "cryptographically-insecure"), deny(deprecated))]
@@ -42,19 +46,10 @@ pub use crate::{{ scheme_name }}::{
     shared_secret_bytes as {{ scheme_name }}_shared_secret_bytes,
     {% else %}
     signature_bytes as {{ scheme_name }}_signature_bytes,
+    sign as {{ scheme_name }}_sign,
+    open as {{ scheme_name }}_open,
     detached_sign as {{ scheme_name }}_detached_sign,
     verify_detached_signature as {{ scheme_name }}_verify_detached_signature,
     {% endif %}
 };
 {% endfor %}
-
-{% if type == "sign" %}
-{% for scheme in schemes %}
-{% set scheme_name = scheme.name|nameize %}
-#[cfg(feature = "std")]
-pub use crate::{{ scheme_name }}::{
-    sign as {{ scheme_name }}_sign,
-    open as {{ scheme_name }}_open,
-};
-{% endfor %}
-{% endif %}

--- a/pqcrypto-template/scheme/src/lib.rs.j2
+++ b/pqcrypto-template/scheme/src/lib.rs.j2
@@ -14,7 +14,12 @@
 {% endfor %}
 {% endif %}
 
+#![no_std]
 #![allow(clippy::len_without_is_empty)]
+
+#[cfg(feature = "std")]
+#[macro_use] extern crate std;
+
 {% if insecure %}
 #![cfg_attr(not(feature = "cryptographically-insecure"), deny(deprecated))]
 {% endif %}
@@ -37,10 +42,19 @@ pub use crate::{{ scheme_name }}::{
     shared_secret_bytes as {{ scheme_name }}_shared_secret_bytes,
     {% else %}
     signature_bytes as {{ scheme_name }}_signature_bytes,
-    sign as {{ scheme_name }}_sign,
-    open as {{ scheme_name }}_open,
     detached_sign as {{ scheme_name }}_detached_sign,
     verify_detached_signature as {{ scheme_name }}_verify_detached_signature,
     {% endif %}
 };
 {% endfor %}
+
+{% if type == "sign" %}
+{% for scheme in schemes %}
+{% set scheme_name = scheme.name|nameize %}
+#[cfg(feature = "std")]
+pub use crate::{{ scheme_name }}::{
+    sign as {{ scheme_name }}_sign,
+    open as {{ scheme_name }}_open,
+};
+{% endfor %}
+{% endif %}

--- a/pqcrypto-template/scheme/src/scheme.rs.j2
+++ b/pqcrypto-template/scheme/src/scheme.rs.j2
@@ -381,7 +381,7 @@ macro_rules! open_signed {
 pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey
-) -> std::result::Result<Vec<u8>,primitive::VerificationError> {
+) -> core::result::Result<Vec<u8>,primitive::VerificationError> {
     {% if 'avx2_implementation' in scheme %}
     #[cfg(enable_avx2)]
     {
@@ -452,7 +452,7 @@ macro_rules! verify_detached_sig {
 {% if insecure %}
 #[deprecated(note = "Insecure cryptography, do not use in production")]
 {% endif %}
-pub fn verify_detached_signature(sig: &DetachedSignature, msg: &[u8], pk: &PublicKey) -> std::result::Result<(), primitive::VerificationError> {
+pub fn verify_detached_signature(sig: &DetachedSignature, msg: &[u8], pk: &PublicKey) -> core::result::Result<(), primitive::VerificationError> {
     {% if 'avx2_implementation' in scheme %}
     #[cfg(enable_avx2)]
     {

--- a/pqcrypto-template/scheme/src/scheme.rs.j2
+++ b/pqcrypto-template/scheme/src/scheme.rs.j2
@@ -39,6 +39,7 @@ use pqcrypto_traits::{Result, Error};
 {% if type == "kem" %}
 use pqcrypto_traits::kem as primitive;
 {% else %}
+use alloc::vec::Vec;
 use pqcrypto_traits::sign as primitive;
 {% endif %}
 
@@ -149,117 +150,26 @@ impl primitive::DetachedSignature for DetachedSignature {
     }
 }
 
-#[cfg(feature = "std")]
-pub use attached_sig::*;
-
-#[cfg(feature = "std")]
-mod attached_sig {
-    use super::*;
-    use std::vec::Vec;
-
-    #[derive(Clone)]
-    #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
-    pub struct SignedMessage(Vec<u8>);
-    impl primitive::SignedMessage for SignedMessage {
-        /// Get this object as a byte slice
-        #[inline]
-        fn as_bytes(&self) -> &[u8] {
-            &self.0.as_slice()
-        }
-
-        /// Construct this object from a byte slice
-        #[inline]
-        fn from_bytes(bytes: &[u8]) -> Result<Self> {
-            Ok(SignedMessage(bytes.to_vec()))
-        }
+#[derive(Clone)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
+pub struct SignedMessage(Vec<u8>);
+impl primitive::SignedMessage for SignedMessage {
+    /// Get this object as a byte slice
+    #[inline]
+    fn as_bytes(&self) -> &[u8] {
+        &self.0.as_slice()
     }
 
-    impl SignedMessage {
-        pub fn len(&self) -> usize {
-            self.0.len()
-        }
+    /// Construct this object from a byte slice
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        Ok(SignedMessage(bytes.to_vec()))
     }
+}
 
-    macro_rules! gen_signature {
-        ($variant:ident, $msg:ident, $sk:ident) => {
-        {
-            let max_len = $msg.len() + signature_bytes();
-            let mut signed_msg = Vec::with_capacity(max_len);
-            let mut smlen: usize = 0;
-            unsafe {
-                ffi::$variant(
-                    signed_msg.as_mut_ptr(),
-                    &mut smlen as *mut usize,
-                    $msg.as_ptr(),
-                    $msg.len(),
-                    $sk.0.as_ptr(),
-                );
-                debug_assert!(smlen <= max_len, "exceeded vector capacity");
-                signed_msg.set_len(smlen);
-            }
-            SignedMessage(signed_msg)
-        }
-        };
-    }
-
-    /// Sign the message and return the signed message.
-    {% if insecure %}
-    #[deprecated(note = "Insecure cryptography, do not use in production")]
-    {% endif %}
-    pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-        {% if 'avx2_implementation' in scheme %}
-        #[cfg(enable_avx2)]
-        {
-            if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
-                return gen_signature!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign, msg, sk);
-            }
-        }
-        {% endif %}
-        gen_signature!(PQCLEAN_{{ NS_NAME }}_crypto_sign, msg, sk)
-    }
-
-    macro_rules! open_signed {
-        ($variant:ident, $sm:ident, $pk:ident) => {
-        {
-            let mut m: Vec<u8> = Vec::with_capacity($sm.len());
-            let mut mlen: usize = 0;
-            match unsafe {
-                ffi::$variant(
-                    m.as_mut_ptr(),
-                    &mut mlen as *mut usize,
-                    $sm.0.as_ptr(),
-                    $sm.len(),
-                    $pk.0.as_ptr(),
-                )
-            } {
-                0 => {
-                    unsafe { m.set_len(mlen) };
-                    Ok(m)
-                }
-                -1 => Err(primitive::VerificationError::InvalidSignature),
-                _ => Err(primitive::VerificationError::UnknownVerificationError),
-            }
-        }
-        };
-    }
-
-    /// Open the signed message and if verification succeeds return the message
-    {% if insecure %}
-    #[deprecated(note = "Insecure cryptography, do not use in production")]
-    {% endif %}
-    pub fn open(
-        sm: &SignedMessage,
-        pk: &PublicKey
-    ) -> core::result::Result<Vec<u8>,primitive::VerificationError> {
-        {% if 'avx2_implementation' in scheme %}
-        #[cfg(enable_avx2)]
-        {
-            if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
-                return open_signed!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign_open, sm, pk);
-            }
-        }
-        {% endif %}
-        open_signed!(PQCLEAN_{{ NS_NAME }}_crypto_sign_open, sm, pk)
+impl SignedMessage {
+    pub fn len(&self) -> usize {
+        self.0.len()
     }
 }
 {% endif %}
@@ -311,9 +221,9 @@ macro_rules! gen_keypair {
 {% endif %}
 pub fn keypair() -> (PublicKey, SecretKey) {
     {% if 'avx2_implementation' in scheme %}
-    #[cfg(enable_avx2)]
+    #[cfg(all(enable_avx2, feature = "avx2"))]
     {
-        if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
+        if std::is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
             {% if type == "kem" %}
             return gen_keypair!(PQCLEAN_{{ AVX2_NAME }}_crypto_kem_keypair);
             {% else %}
@@ -353,9 +263,9 @@ macro_rules! encap {
 {% endif %}
 pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
     {% if 'avx2_implementation' in scheme %}
-    #[cfg(enable_avx2)]
+    #[cfg(all(enable_avx2, feature = "avx2"))]
     {
-        if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
+        if std::is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
             return encap!(PQCLEAN_{{ AVX2_NAME }}_crypto_kem_enc, pk);
         }
     }
@@ -388,9 +298,9 @@ macro_rules! decap {
 {% endif %}
 pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
     {% if 'avx2_implementation' in scheme %}
-    #[cfg(enable_avx2)]
+    #[cfg(all(enable_avx2, feature = "avx2"))]
     {
-        if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
+        if std::is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
             return decap!(PQCLEAN_{{ AVX2_NAME }}_crypto_kem_dec, ct, sk);
         }
     }
@@ -401,6 +311,88 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
 
 {% else %}
 
+
+macro_rules! gen_signature {
+    ($variant:ident, $msg:ident, $sk:ident) => {
+    {
+        let max_len = $msg.len() + signature_bytes();
+        let mut signed_msg = Vec::with_capacity(max_len);
+        let mut smlen: usize = 0;
+        unsafe {
+            ffi::$variant(
+                signed_msg.as_mut_ptr(),
+                &mut smlen as *mut usize,
+                $msg.as_ptr(),
+                $msg.len(),
+                $sk.0.as_ptr(),
+            );
+            debug_assert!(smlen <= max_len, "exceeded vector capacity");
+            signed_msg.set_len(smlen);
+        }
+        SignedMessage(signed_msg)
+    }
+    };
+}
+
+/// Sign the message and return the signed message.
+{% if insecure %}
+#[deprecated(note = "Insecure cryptography, do not use in production")]
+{% endif %}
+pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
+    {% if 'avx2_implementation' in scheme %}
+    #[cfg(all(enable_avx2, feature = "avx2"))]
+    {
+        if std::is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
+            return gen_signature!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign, msg, sk);
+        }
+    }
+    {% endif %}
+    gen_signature!(PQCLEAN_{{ NS_NAME }}_crypto_sign, msg, sk)
+}
+
+macro_rules! open_signed {
+    ($variant:ident, $sm:ident, $pk:ident) => {
+    {
+        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+        let mut mlen: usize = 0;
+        match unsafe {
+            ffi::$variant(
+                m.as_mut_ptr(),
+                &mut mlen as *mut usize,
+                $sm.0.as_ptr(),
+                $sm.len(),
+                $pk.0.as_ptr(),
+            )
+        } {
+            0 => {
+                unsafe { m.set_len(mlen) };
+                Ok(m)
+            }
+            -1 => Err(primitive::VerificationError::InvalidSignature),
+            _ => Err(primitive::VerificationError::UnknownVerificationError),
+        }
+    }
+    };
+}
+
+/// Open the signed message and if verification succeeds return the message
+{% if insecure %}
+#[deprecated(note = "Insecure cryptography, do not use in production")]
+{% endif %}
+pub fn open(
+    sm: &SignedMessage,
+    pk: &PublicKey
+) -> core::result::Result<Vec<u8>,primitive::VerificationError> {
+    {% if 'avx2_implementation' in scheme %}
+    #[cfg(all(enable_avx2, feature = "avx2"))]
+    {
+        if std::is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
+            return open_signed!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign_open, sm, pk);
+        }
+    }
+    {% endif %}
+    open_signed!(PQCLEAN_{{ NS_NAME }}_crypto_sign_open, sm, pk)
+}
 
 macro_rules! detached_signature {
     ($variant:ident, $msg:ident, $sk:ident) => {
@@ -426,9 +418,9 @@ macro_rules! detached_signature {
 /// Create a detached signature on the message
 pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
     {% if 'avx2_implementation' in scheme %}
-    #[cfg(enable_avx2)]
+    #[cfg(all(enable_avx2, feature = "avx2"))]
     {
-        if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
+        if std::is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
             return detached_signature!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign_signature, msg, sk);
         }
     }
@@ -463,9 +455,9 @@ macro_rules! verify_detached_sig {
 {% endif %}
 pub fn verify_detached_signature(sig: &DetachedSignature, msg: &[u8], pk: &PublicKey) -> core::result::Result<(), primitive::VerificationError> {
     {% if 'avx2_implementation' in scheme %}
-    #[cfg(enable_avx2)]
+    #[cfg(all(enable_avx2, feature = "avx2"))]
     {
-        if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
+        if std::is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
             return verify_detached_sig!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign_verify, sig, msg, pk);
         }
     }
@@ -481,7 +473,6 @@ pub fn verify_detached_signature(sig: &DetachedSignature, msg: &[u8], pk: &Publi
 mod test {
     use super::*;
 {% if type == "sign" %}
-    use std::vec::Vec;
     use rand::prelude::*;
 {% endif %}
 

--- a/pqcrypto-template/scheme/src/scheme.rs.j2
+++ b/pqcrypto-template/scheme/src/scheme.rs.j2
@@ -149,26 +149,117 @@ impl primitive::DetachedSignature for DetachedSignature {
     }
 }
 
-#[derive(Clone)]
-#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
-pub struct SignedMessage(Vec<u8>);
-impl primitive::SignedMessage for SignedMessage {
-    /// Get this object as a byte slice
-    #[inline]
-    fn as_bytes(&self) -> &[u8] {
-        &self.0.as_slice()
+#[cfg(feature = "std")]
+pub use attached_sig::*;
+
+#[cfg(feature = "std")]
+mod attached_sig {
+    use super::*;
+    use std::vec::Vec;
+
+    #[derive(Clone)]
+    #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
+    pub struct SignedMessage(Vec<u8>);
+    impl primitive::SignedMessage for SignedMessage {
+        /// Get this object as a byte slice
+        #[inline]
+        fn as_bytes(&self) -> &[u8] {
+            &self.0.as_slice()
+        }
+
+        /// Construct this object from a byte slice
+        #[inline]
+        fn from_bytes(bytes: &[u8]) -> Result<Self> {
+            Ok(SignedMessage(bytes.to_vec()))
+        }
     }
 
-    /// Construct this object from a byte slice
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        Ok(SignedMessage(bytes.to_vec()))
+    impl SignedMessage {
+        pub fn len(&self) -> usize {
+            self.0.len()
+        }
     }
-}
 
-impl SignedMessage {
-    pub fn len(&self) -> usize {
-        self.0.len()
+    macro_rules! gen_signature {
+        ($variant:ident, $msg:ident, $sk:ident) => {
+        {
+            let max_len = $msg.len() + signature_bytes();
+            let mut signed_msg = Vec::with_capacity(max_len);
+            let mut smlen: usize = 0;
+            unsafe {
+                ffi::$variant(
+                    signed_msg.as_mut_ptr(),
+                    &mut smlen as *mut usize,
+                    $msg.as_ptr(),
+                    $msg.len(),
+                    $sk.0.as_ptr(),
+                );
+                debug_assert!(smlen <= max_len, "exceeded vector capacity");
+                signed_msg.set_len(smlen);
+            }
+            SignedMessage(signed_msg)
+        }
+        };
+    }
+
+    /// Sign the message and return the signed message.
+    {% if insecure %}
+    #[deprecated(note = "Insecure cryptography, do not use in production")]
+    {% endif %}
+    pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
+        {% if 'avx2_implementation' in scheme %}
+        #[cfg(enable_avx2)]
+        {
+            if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
+                return gen_signature!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign, msg, sk);
+            }
+        }
+        {% endif %}
+        gen_signature!(PQCLEAN_{{ NS_NAME }}_crypto_sign, msg, sk)
+    }
+
+    macro_rules! open_signed {
+        ($variant:ident, $sm:ident, $pk:ident) => {
+        {
+            let mut m: Vec<u8> = Vec::with_capacity($sm.len());
+            let mut mlen: usize = 0;
+            match unsafe {
+                ffi::$variant(
+                    m.as_mut_ptr(),
+                    &mut mlen as *mut usize,
+                    $sm.0.as_ptr(),
+                    $sm.len(),
+                    $pk.0.as_ptr(),
+                )
+            } {
+                0 => {
+                    unsafe { m.set_len(mlen) };
+                    Ok(m)
+                }
+                -1 => Err(primitive::VerificationError::InvalidSignature),
+                _ => Err(primitive::VerificationError::UnknownVerificationError),
+            }
+        }
+        };
+    }
+
+    /// Open the signed message and if verification succeeds return the message
+    {% if insecure %}
+    #[deprecated(note = "Insecure cryptography, do not use in production")]
+    {% endif %}
+    pub fn open(
+        sm: &SignedMessage,
+        pk: &PublicKey
+    ) -> core::result::Result<Vec<u8>,primitive::VerificationError> {
+        {% if 'avx2_implementation' in scheme %}
+        #[cfg(enable_avx2)]
+        {
+            if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
+                return open_signed!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign_open, sm, pk);
+            }
+        }
+        {% endif %}
+        open_signed!(PQCLEAN_{{ NS_NAME }}_crypto_sign_open, sm, pk)
     }
 }
 {% endif %}
@@ -311,88 +402,6 @@ pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
 {% else %}
 
 
-macro_rules! gen_signature {
-    ($variant:ident, $msg:ident, $sk:ident) => {
-    {
-        let max_len = $msg.len() + signature_bytes();
-        let mut signed_msg = Vec::with_capacity(max_len);
-        let mut smlen: usize = 0;
-        unsafe {
-            ffi::$variant(
-                signed_msg.as_mut_ptr(),
-                &mut smlen as *mut usize,
-                $msg.as_ptr(),
-                $msg.len(),
-                $sk.0.as_ptr(),
-            );
-            debug_assert!(smlen <= max_len, "exceeded vector capacity");
-            signed_msg.set_len(smlen);
-        }
-        SignedMessage(signed_msg)
-    }
-    };
-}
-
-/// Sign the message and return the signed message.
-{% if insecure %}
-#[deprecated(note = "Insecure cryptography, do not use in production")]
-{% endif %}
-pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    {% if 'avx2_implementation' in scheme %}
-    #[cfg(enable_avx2)]
-    {
-        if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
-            return gen_signature!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign, msg, sk);
-        }
-    }
-    {% endif %}
-    gen_signature!(PQCLEAN_{{ NS_NAME }}_crypto_sign, msg, sk)
-}
-
-macro_rules! open_signed {
-    ($variant:ident, $sm:ident, $pk:ident) => {
-    {
-        let mut m: Vec<u8> = Vec::with_capacity($sm.len());
-        let mut mlen: usize = 0;
-        match unsafe {
-            ffi::$variant(
-                m.as_mut_ptr(),
-                &mut mlen as *mut usize,
-                $sm.0.as_ptr(),
-                $sm.len(),
-                $pk.0.as_ptr(),
-            )
-        } {
-            0 => {
-                unsafe { m.set_len(mlen) };
-                Ok(m)
-            }
-            -1 => Err(primitive::VerificationError::InvalidSignature),
-            _ => Err(primitive::VerificationError::UnknownVerificationError),
-        }
-    }
-    };
-}
-
-/// Open the signed message and if verification succeeds return the message
-{% if insecure %}
-#[deprecated(note = "Insecure cryptography, do not use in production")]
-{% endif %}
-pub fn open(
-    sm: &SignedMessage,
-    pk: &PublicKey
-) -> core::result::Result<Vec<u8>,primitive::VerificationError> {
-    {% if 'avx2_implementation' in scheme %}
-    #[cfg(enable_avx2)]
-    {
-        if is_x86_feature_detected!("{{ scheme.avx2_feature }}") {
-            return open_signed!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign_open, sm, pk);
-        }
-    }
-    {% endif %}
-    open_signed!(PQCLEAN_{{ NS_NAME }}_crypto_sign_open, sm, pk)
-}
-
 macro_rules! detached_signature {
     ($variant:ident, $msg:ident, $sk:ident) => {
     {
@@ -472,6 +481,7 @@ pub fn verify_detached_signature(sig: &DetachedSignature, msg: &[u8], pk: &Publi
 mod test {
     use super::*;
 {% if type == "sign" %}
+    use std::vec::Vec;
     use rand::prelude::*;
 {% endif %}
 

--- a/pqcrypto-traits/Cargo.toml
+++ b/pqcrypto-traits/Cargo.toml
@@ -8,6 +8,10 @@ license = "MIT OR Apache-2.0"
 homepage = "https://github.com/rustpq/"
 repository = "https://github.com/rustpq/pqclean/"
 keywords = ["cryptography", "post-quantum", "security"]
-categories = ["cryptography"]
+categories = ["cryptography", "no-std"]
 
 [dependencies]
+
+[features]
+default = ["std"]
+std = []

--- a/pqcrypto-traits/src/lib.rs
+++ b/pqcrypto-traits/src/lib.rs
@@ -1,5 +1,6 @@
+//! Supporting Traits for the pqcrypto crates.
+
 #![no_std]
-/// Supporting Traits for the pqcrypto crates.
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/pqcrypto-traits/src/lib.rs
+++ b/pqcrypto-traits/src/lib.rs
@@ -1,7 +1,11 @@
+#![no_std]
 /// Supporting Traits for the pqcrypto crates.
 
+#[cfg(feature = "std")]
+extern crate std;
+
 /// Convenience wrapper for Result
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 /// Errors that may arise when constructing keys or signatures.
 #[derive(Clone, Copy, Debug)]
@@ -14,8 +18,8 @@ pub enum Error {
     },
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             Error::BadLength {
                 name,
@@ -30,6 +34,7 @@ impl std::fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
 pub mod kem;

--- a/pqcrypto-traits/src/sign.rs
+++ b/pqcrypto-traits/src/sign.rs
@@ -55,8 +55,8 @@ pub enum VerificationError {
     UnknownVerificationError,
 }
 
-impl std::fmt::Display for VerificationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
+impl core::fmt::Display for VerificationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::result::Result<(), core::fmt::Error> {
         match self {
             VerificationError::InvalidSignature => write!(f, "error: verification failed"),
             VerificationError::UnknownVerificationError => write!(f, "unknown error"),
@@ -64,4 +64,5 @@ impl std::fmt::Display for VerificationError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for VerificationError {}

--- a/pqcrypto/Cargo.toml
+++ b/pqcrypto/Cargo.toml
@@ -12,22 +12,23 @@ keywords = ["cryptography", "post-quantum", "security"]
 categories = ["cryptography"]
 
 [dependencies]
-pqcrypto-traits = { path = "../pqcrypto-traits", version = "0.3.2" }
-pqcrypto-kyber = { path = "../pqcrypto-kyber", version = "0.7.1", optional = true }
-pqcrypto-frodo = { path = "../pqcrypto-frodo", version = "0.4.7", optional = true }
-pqcrypto-ntru = { path = "../pqcrypto-ntru", version = "0.5.4", optional = true }
-pqcrypto-ntruprime = { path = "../pqcrypto-ntruprime", version = "0.1.2", optional = true }
-pqcrypto-saber = { path = "../pqcrypto-saber", version = "0.1.7", optional = true }
-pqcrypto-classicmceliece = { path = "../pqcrypto-classicmceliece", version = "0.1.3", optional = true }
-pqcrypto-hqc = { path = "../pqcrypto-hqc", version = "0.1.1", optional = true }
-pqcrypto-dilithium = { path = "../pqcrypto-dilithium", version = "0.4.1", optional = true }
-pqcrypto-falcon = { path = "../pqcrypto-falcon", version = "0.2.7", optional = true }
-pqcrypto-rainbow = { path = "../pqcrypto-rainbow", version = "0.2.1", optional = true }
-pqcrypto-sphincsplus = { path = "../pqcrypto-sphincsplus", version = "0.6.0", optional = true }
+pqcrypto-traits = { path = "../pqcrypto-traits", version = "0.3.2", default-features = false }
+pqcrypto-kyber = { path = "../pqcrypto-kyber", version = "0.7.1", optional = true, default-features = false }
+pqcrypto-frodo = { path = "../pqcrypto-frodo", version = "0.4.7", optional = true, default-features = false }
+pqcrypto-ntru = { path = "../pqcrypto-ntru", version = "0.5.4", optional = true, default-features = false }
+pqcrypto-ntruprime = { path = "../pqcrypto-ntruprime", version = "0.1.2", optional = true, default-features = false }
+pqcrypto-saber = { path = "../pqcrypto-saber", version = "0.1.7", optional = true, default-features = false }
+pqcrypto-classicmceliece = { path = "../pqcrypto-classicmceliece", version = "0.1.3", optional = true, default-features = false }
+pqcrypto-hqc = { path = "../pqcrypto-hqc", version = "0.1.1", optional = true, default-features = false }
+pqcrypto-dilithium = { path = "../pqcrypto-dilithium", version = "0.4.1", optional = true, default-features = false }
+pqcrypto-falcon = { path = "../pqcrypto-falcon", version = "0.2.7", optional = true, default-features = false }
+pqcrypto-rainbow = { path = "../pqcrypto-rainbow", version = "0.2.1", optional = true, default-features = false }
+pqcrypto-sphincsplus = { path = "../pqcrypto-sphincsplus", version = "0.6.0", optional = true, default-features = false }
 
 [features]
-default = ["pqcrypto-kyber","pqcrypto-frodo","pqcrypto-ntru","pqcrypto-ntruprime","pqcrypto-saber","pqcrypto-classicmceliece","pqcrypto-hqc","pqcrypto-dilithium","pqcrypto-falcon","pqcrypto-rainbow","pqcrypto-sphincsplus",]
+default = ["std","pqcrypto-kyber","pqcrypto-frodo","pqcrypto-ntru","pqcrypto-ntruprime","pqcrypto-saber","pqcrypto-classicmceliece","pqcrypto-hqc","pqcrypto-dilithium","pqcrypto-falcon","pqcrypto-rainbow","pqcrypto-sphincsplus",]
 cryptographically-insecure = []
+std = ["pqcrypto-traits/std","pqcrypto-kyber/std","pqcrypto-frodo/std","pqcrypto-ntru/std","pqcrypto-ntruprime/std","pqcrypto-saber/std","pqcrypto-classicmceliece/std","pqcrypto-hqc/std","pqcrypto-dilithium/std","pqcrypto-falcon/std","pqcrypto-rainbow/std","pqcrypto-sphincsplus/std",]
 serialization = ["pqcrypto-kyber/serialization","pqcrypto-frodo/serialization","pqcrypto-ntru/serialization","pqcrypto-ntruprime/serialization","pqcrypto-saber/serialization","pqcrypto-classicmceliece/serialization","pqcrypto-hqc/serialization","pqcrypto-dilithium/serialization","pqcrypto-falcon/serialization","pqcrypto-rainbow/serialization","pqcrypto-sphincsplus/serialization",]
 
 [badges]

--- a/pqcrypto/Cargo.toml
+++ b/pqcrypto/Cargo.toml
@@ -12,23 +12,22 @@ keywords = ["cryptography", "post-quantum", "security"]
 categories = ["cryptography"]
 
 [dependencies]
-pqcrypto-traits = { path = "../pqcrypto-traits", version = "0.3.2", default-features = false }
-pqcrypto-kyber = { path = "../pqcrypto-kyber", version = "0.7.1", optional = true, default-features = false }
-pqcrypto-frodo = { path = "../pqcrypto-frodo", version = "0.4.7", optional = true, default-features = false }
-pqcrypto-ntru = { path = "../pqcrypto-ntru", version = "0.5.4", optional = true, default-features = false }
-pqcrypto-ntruprime = { path = "../pqcrypto-ntruprime", version = "0.1.2", optional = true, default-features = false }
-pqcrypto-saber = { path = "../pqcrypto-saber", version = "0.1.7", optional = true, default-features = false }
-pqcrypto-classicmceliece = { path = "../pqcrypto-classicmceliece", version = "0.1.3", optional = true, default-features = false }
-pqcrypto-hqc = { path = "../pqcrypto-hqc", version = "0.1.1", optional = true, default-features = false }
-pqcrypto-dilithium = { path = "../pqcrypto-dilithium", version = "0.4.1", optional = true, default-features = false }
-pqcrypto-falcon = { path = "../pqcrypto-falcon", version = "0.2.7", optional = true, default-features = false }
-pqcrypto-rainbow = { path = "../pqcrypto-rainbow", version = "0.2.1", optional = true, default-features = false }
-pqcrypto-sphincsplus = { path = "../pqcrypto-sphincsplus", version = "0.6.0", optional = true, default-features = false }
+pqcrypto-traits = { path = "../pqcrypto-traits", version = "0.3.2" }
+pqcrypto-kyber = { path = "../pqcrypto-kyber", version = "0.7.1", optional = true }
+pqcrypto-frodo = { path = "../pqcrypto-frodo", version = "0.4.7", optional = true }
+pqcrypto-ntru = { path = "../pqcrypto-ntru", version = "0.5.4", optional = true }
+pqcrypto-ntruprime = { path = "../pqcrypto-ntruprime", version = "0.1.2", optional = true }
+pqcrypto-saber = { path = "../pqcrypto-saber", version = "0.1.7", optional = true }
+pqcrypto-classicmceliece = { path = "../pqcrypto-classicmceliece", version = "0.1.3", optional = true }
+pqcrypto-hqc = { path = "../pqcrypto-hqc", version = "0.1.1", optional = true }
+pqcrypto-dilithium = { path = "../pqcrypto-dilithium", version = "0.4.1", optional = true }
+pqcrypto-falcon = { path = "../pqcrypto-falcon", version = "0.2.7", optional = true }
+pqcrypto-rainbow = { path = "../pqcrypto-rainbow", version = "0.2.1", optional = true }
+pqcrypto-sphincsplus = { path = "../pqcrypto-sphincsplus", version = "0.6.0", optional = true }
 
 [features]
-default = ["std","pqcrypto-kyber","pqcrypto-frodo","pqcrypto-ntru","pqcrypto-ntruprime","pqcrypto-saber","pqcrypto-classicmceliece","pqcrypto-hqc","pqcrypto-dilithium","pqcrypto-falcon","pqcrypto-rainbow","pqcrypto-sphincsplus",]
+default = ["pqcrypto-kyber","pqcrypto-frodo","pqcrypto-ntru","pqcrypto-ntruprime","pqcrypto-saber","pqcrypto-classicmceliece","pqcrypto-hqc","pqcrypto-dilithium","pqcrypto-falcon","pqcrypto-rainbow","pqcrypto-sphincsplus",]
 cryptographically-insecure = []
-std = ["pqcrypto-traits/std","pqcrypto-kyber/std","pqcrypto-frodo/std","pqcrypto-ntru/std","pqcrypto-ntruprime/std","pqcrypto-saber/std","pqcrypto-classicmceliece/std","pqcrypto-hqc/std","pqcrypto-dilithium/std","pqcrypto-falcon/std","pqcrypto-rainbow/std","pqcrypto-sphincsplus/std",]
 serialization = ["pqcrypto-kyber/serialization","pqcrypto-frodo/serialization","pqcrypto-ntru/serialization","pqcrypto-ntruprime/serialization","pqcrypto-saber/serialization","pqcrypto-classicmceliece/serialization","pqcrypto-hqc/serialization","pqcrypto-dilithium/serialization","pqcrypto-falcon/serialization","pqcrypto-rainbow/serialization","pqcrypto-sphincsplus/serialization",]
 
 [badges]


### PR DESCRIPTION
The pqcrypto crates are essentially already `no-std`, but they never specified it. Enabling this feature allows them to be used on embedded systems which perhaps don't have `std` support. The only real end-user change is that `pqcrypto_traits::VerificationError` will not `impl std::error::Error` when the `std` flag isn't set. I didn't include any of the generated files in the PR because that'd be wayyy too much to look at. You can regen yourself and hopefully see that everything is in order.

Last note: the new feature flag is `std` and it's included by default in every crate. I also noticed that the `avx2` flag was never actually checked anywhere, so I took the liberty of including it where appropriate. Since the code within always uses `std::is_x86_feature_detected`, I made the `avx2` feature always require `std`.