### PR TITLE
Add AArch64 support for selected schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2021-12-07
+
+* Add AArch64 compilation option for supported schemes
+  * NTT operations can now compute with NEON support
+
+## 2021-12-01
+
+* Add WebAssembly (WASM) support
+
 ## 2021-11-24
 
 * Add a general implementation list for each scheme in implementations.yaml which is used by build.rs.j2

--- a/generate-implementations.py
+++ b/generate-implementations.py
@@ -8,8 +8,9 @@ import re
 import shutil
 
 
-DEFAULT_AVX2_GUARD = 'avx2_enabled && target_arch == "x86_64"'
-DEFAULT_AES_GUARD = 'aes_enabled && target_arch == "x86_64"'
+DEFAULT_X86_AES_GUARD = 'target_arch == "x86_64" && aes_enabled'
+DEFAULT_X86_AVX2_GUARD = 'target_arch == "x86_64" && avx2_enabled'
+DEFAULT_AARCH64_NEON_GUARD = 'target_arch == "aarch64" && neon_enabled'
 
 
 def read_yaml():
@@ -82,8 +83,9 @@ def generate_scheme(name, type, properties):
         type=type,
         implementations=properties['implementations'],
         schemes=properties['schemes'],
-        avx2_guard=properties.get('avx2_guard', DEFAULT_AVX2_GUARD),
-        aes_guard=properties.get('aes_guard', DEFAULT_AES_GUARD),
+        x86_aes_guard=properties.get('x86_aes_guard', DEFAULT_X86_AES_GUARD),
+        x86_avx2_guard=properties.get('x86_avx2_guard', DEFAULT_X86_AVX2_GUARD),
+        aarch64_neon_guard=properties.get('aarch64_neon_guard', DEFAULT_AARCH64_NEON_GUARD),
     )
 
     metadatas = dict()

--- a/implementations.yaml
+++ b/implementations.yaml
@@ -6,21 +6,21 @@ traits_version: 0.3.4
 kems:
   kyber:
     version: 0.7.4
-    avx2_guard: 'avx2_enabled && !is_windows && !is_macos && target_arch == "x86_64"'
-    implementations: [clean, avx2]
+    x86_avx2_guard: 'target_arch == "x86_64" && avx2_enabled && !is_windows && !is_macos'
+    implementations: [clean, avx2, aarch64]
     schemes:
       - name: kyber512
-        implementations: [clean, avx2]
+        implementations: [clean, avx2, aarch64]
       - name: kyber768
-        implementations: [clean, avx2]
+        implementations: [clean, avx2, aarch64]
       - name: kyber1024
-        implementations: [clean, avx2]
+        implementations: [clean, avx2, aarch64]
       - name: kyber512-90s
-        implementations: [clean, avx2]
+        implementations: [clean, avx2, aarch64]
       - name: kyber768-90s
-        implementations: [clean, avx2]
+        implementations: [clean, avx2, aarch64]
       - name: kyber1024-90s
-        implementations: [clean, avx2]
+        implementations: [clean, avx2, aarch64]
   frodo:
     version: 0.4.10
     notes: |
@@ -89,20 +89,20 @@ kems:
         implementations: [clean, avx2]
   saber:
     version: 0.1.10
-    implementations: [clean, avx2]
+    implementations: [clean, avx2, aarch64]
     schemes:
       - name: firesaber
-        implementations: [clean, avx2]
+        implementations: [clean, avx2, aarch64]
       - name: lightsaber
-        implementations: [clean, avx2]
+        implementations: [clean, avx2, aarch64]
       - name: saber
-        implementations: [clean, avx2]
+        implementations: [clean, avx2, aarch64]
   classicmceliece:
     version: 0.1.6
     notes: |
       This implementation requires a lot of stack space.
       You need to specify ``RUST_MIN_STACK=800000000``, probably.
-    avx2_guard: 'avx2_enabled && !is_windows && target_arch == "x86_64"'
+    x86_avx2_guard: 'target_arch == "x86_64" && avx2_enabled && !is_windows'
     implementations: [vec, clean, avx]
     schemes:
       - name: mceliece348864
@@ -146,15 +146,15 @@ kems:
 signs:
   dilithium:
     version: 0.4.4
-    avx2_guard: 'avx2_enabled && !is_windows && target_arch == "x86_64"'
-    implementations: [clean, avx2]
+    x86_avx2_guard: 'target_arch == "x86_64" && avx2_enabled && !is_windows'
+    implementations: [clean, avx2, aarch64]
     schemes:
       - name: dilithium2
-        implementations: [clean, avx2]
+        implementations: [clean, avx2, aarch64]
       - name: dilithium3
-        implementations: [clean, avx2]
+        implementations: [clean, avx2, aarch64]
       - name: dilithium5
-        implementations: [clean, avx2]
+        implementations: [clean, avx2, aarch64]
   falcon:
     version: 0.2.10
     implementations: [clean, avx2]

--- a/pqcrypto-template/scheme/Cargo.toml.j2
+++ b/pqcrypto-template/scheme/Cargo.toml.j2
@@ -19,12 +19,15 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde-big-array = { version = "0.3.2", features = ["const-generics"], optional = true }
 
 [features]
-default = [{% if 'avx2' in implementations or 'avx' in implementations %}"avx2", {% endif %}{% if 'aesni' in implementations %}"aes", {% endif %}"std"]
+default = [{% if 'avx2' in implementations or 'avx' in implementations %}"avx2", {% endif %}{% if 'aesni' in implementations %}"aes", {% endif %}{% if 'aarch64' in implementations %}"neon", {% endif %}"std"]
 {% if 'avx2' in implementations or 'avx' in implementations %}
 avx2 = ["std"]
 {% endif %}
 {% if 'aesni' in implementations %}
 aes = ["std"]
+{% endif %}
+{% if 'aarch64' in implementations %}
+neon = ["std"]
 {% endif %}
 std = ["pqcrypto-traits/std"]
 serialization = ["serde", "serde-big-array"]

--- a/pqcrypto-template/scheme/README.md.j2
+++ b/pqcrypto-template/scheme/README.md.j2
@@ -28,10 +28,10 @@ methods only.
 {% for scheme in schemes %}
 * ``{{ scheme.name }}``
 {% for implementation in scheme.implementations %}
-{% if implementation == 'avx2' or implementation == 'avx' or implementation == 'aesni' %}
-  * ``{{ implementation }}`` (if supported)
+{% if implementation == 'clean' %}
+  * ``{{ implementation }}`` (default)
 {% else %}
-  * ``{{ implementation }}``
+  * ``{{ implementation }}`` (if supported)
 {% endif %}
 {% endfor %}{# implementations #}
 {% endfor %}{# schemes #}

--- a/pqcrypto-template/scheme/README.md.j2
+++ b/pqcrypto-template/scheme/README.md.j2
@@ -28,10 +28,10 @@ methods only.
 {% for scheme in schemes %}
 * ``{{ scheme.name }}``
 {% for implementation in scheme.implementations %}
-{% if implementation == 'clean' %}
-  * ``{{ implementation }}`` (default)
-{% else %}
+{% if implementation == 'avx2' or implementation == 'avx' or implementation == 'aesni' or implementation == 'aarch64' %}
   * ``{{ implementation }}`` (if supported)
+{% else %}
+  * ``{{ implementation }}``
 {% endif %}
 {% endfor %}{# implementations #}
 {% endfor %}{# schemes #}

--- a/pqcrypto-template/scheme/build.rs.j2
+++ b/pqcrypto-template/scheme/build.rs.j2
@@ -5,8 +5,9 @@ use std::env;
 use std::path::{Path, PathBuf};
 
 {% set globals = namespace() %}
-{% set globals.have_avx2 = False %}
-{% set globals.have_aes = False %}
+{% set globals.x86_aes = False %}
+{% set globals.x86_avx2 = False %}
+{% set globals.aarch64_neon = False %}
 
 {% for implementation in implementations %}
 macro_rules! build_{{ implementation }} {
@@ -26,7 +27,7 @@ macro_rules! build_{{ implementation }} {
         }
 
         {% if implementation == 'avx2' or implementation == 'avx' %}
-        {% set globals.have_avx2 = True %}
+        {% set globals.x86_avx2 = True %}
         let scheme_files = glob::glob(target_dir.join("*.[csS]").to_str().unwrap()).unwrap();
         if cfg!(target_env = "msvc") {
             builder.flag("/arch:AVX2");
@@ -40,7 +41,7 @@ macro_rules! build_{{ implementation }} {
                 .flag("-mpclmul");
         }
         {% elif implementation == 'aesni' %}
-        {% set globals.have_aes = True %}
+        {% set globals.x86_aes = True %}
         let scheme_files = glob::glob(target_dir.join("*.[csS]").to_str().unwrap()).unwrap();
         if cfg!(target_env = "msvc") {
             builder.flag("/arch:AVX2");
@@ -48,6 +49,10 @@ macro_rules! build_{{ implementation }} {
             builder
                 .flag("-maes");
         }
+        {% elif implementation == 'aarch64' %}
+        {% set globals.aarch64_neon = True %}
+        let scheme_files = glob::glob(target_dir.join("*.[csS]").to_str().unwrap()).unwrap();
+        builder.flag("-march=armv8-a");
         {% else %}
         let scheme_files = glob::glob(target_dir.join("*.c").to_str().unwrap()).unwrap();
         {% endif %}
@@ -69,9 +74,11 @@ macro_rules! build_{{ implementation }} {
 
 fn main() {
     #[allow(unused_variables)]
+    let aes_enabled = env::var("CARGO_FEATURE_AES").is_ok();
+    #[allow(unused_variables)]
     let avx2_enabled = env::var("CARGO_FEATURE_AVX2").is_ok();
     #[allow(unused_variables)]
-    let aes_enabled = env::var("CARGO_FEATURE_AES").is_ok();
+    let neon_enabled = env::var("CARGO_FEATURE_NEON").is_ok();
     #[allow(unused_variables)]
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     #[allow(unused_variables)]
@@ -84,11 +91,15 @@ fn main() {
     {% for scheme in schemes %}
     {% for implementation in scheme.implementations %}
     {% if implementation == 'avx2' or implementation == 'avx' %}
-    if {{ avx2_guard }} {
+    if {{ x86_avx2_guard }} {
         build_{{ implementation }}!("{{ scheme.name }}");
     }
     {% elif implementation == 'aesni' %}
-    if {{ aes_guard }} {
+    if {{ x86_aes_guard }} {
+        build_{{ implementation }}!("{{ scheme.name }}");
+    }
+    {% elif implementation == 'aarch64' %}
+    if {{ aarch64_neon_guard }} {
         build_{{ implementation }}!("{{ scheme.name }}");
     }
     {% else %}
@@ -97,16 +108,22 @@ fn main() {
     {% endfor %}
     {% endfor %}
 
-    {% if globals.have_avx2 %}
-    if {{ avx2_guard }} {
+    {% if globals.x86_avx2 %}
+    if {{ x86_avx2_guard }} {
         // Print enableing flag for AVX2 implementation
-        println!("cargo:rustc-cfg=enable_avx2");
+        println!("cargo:rustc-cfg=enable_x86_avx2");
     }
     {% endif %}
-    {% if globals.have_aes %}
-    if {{ aes_guard }} {
+    {% if globals.x86_aes %}
+    if {{ x86_aes_guard }} {
         // Print enableing flag for AES implementation
-        println!("cargo:rustc-cfg=enable_aes");
+        println!("cargo:rustc-cfg=enable_x86_aes");
+    }
+    {% endif %}
+    {% if globals.aarch64_neon %}
+    if {{ aarch64_neon_guard }} {
+        // Print enableing flag for AARCH64 implementation
+        println!("cargo:rustc-cfg=enable_aarch64_neon");
     }
     {% endif %}
 }

--- a/pqcrypto-template/scheme/src/ffi.rs.j2
+++ b/pqcrypto-template/scheme/src/ffi.rs.j2
@@ -19,18 +19,22 @@ use pqcrypto_internals::*;
 {% set NS_NAME = [scheme.name|namespaceize, implementation|namespaceize]|join('_') %}
 
 {% if implementation == 'avx2' or implementation == 'avx' %}
-#[cfg(enable_avx2)]
+#[cfg(enable_x86_avx2)]
 {% elif implementation == 'aesni' %}
-#[cfg(enable_aes)]
+#[cfg(enable_x86_aes)]
+{% elif implementation == 'aarch64' %}
+#[cfg(enable_aarch64_neon)]
 {% endif %}
 {% if insecure %}
 #[deprecated(note = "Insecure cryptography, do not use in production")]
 {% endif %}
 pub const PQCLEAN_{{ NS_NAME }}_CRYPTO_SECRETKEYBYTES: usize = {{ metadata['length-secret-key'] }};
 {% if implementation == 'avx2' or implementation == 'avx' %}
-#[cfg(enable_avx2)]
+#[cfg(enable_x86_avx2)]
 {% elif implementation == 'aesni' %}
-#[cfg(enable_aes)]
+#[cfg(enable_x86_aes)]
+{% elif implementation == 'aarch64' %}
+#[cfg(enable_aarch64_neon)]
 {% endif %}
 {% if insecure %}
 #[deprecated(note = "Insecure cryptography, do not use in production")]
@@ -38,18 +42,22 @@ pub const PQCLEAN_{{ NS_NAME }}_CRYPTO_SECRETKEYBYTES: usize = {{ metadata['leng
 pub const PQCLEAN_{{ NS_NAME }}_CRYPTO_PUBLICKEYBYTES: usize = {{ metadata['length-public-key'] }};
 {% if type == "kem" %}
     {% if implementation == 'avx2' or implementation == 'avx' %}
-    #[cfg(enable_avx2)]
+    #[cfg(enable_x86_avx2)]
     {% elif implementation == 'aesni' %}
-    #[cfg(enable_aes)]
+    #[cfg(enable_x86_aes)]
+    {% elif implementation == 'aarch64' %}
+    #[cfg(enable_aarch64_neon)]
     {% endif %}
     {% if insecure %}
     #[deprecated(note = "Insecure cryptography, do not use in production")]
     {% endif %}
     pub const PQCLEAN_{{ NS_NAME }}_CRYPTO_CIPHERTEXTBYTES: usize = {{ metadata['length-ciphertext'] }};
     {% if implementation == 'avx2' or implementation == 'avx' %}
-    #[cfg(enable_avx2)]
+    #[cfg(enable_x86_avx2)]
     {% elif implementation == 'aesni' %}
-    #[cfg(enable_aes)]
+    #[cfg(enable_x86_aes)]
+    {% elif implementation == 'aarch64' %}
+    #[cfg(enable_aarch64_neon)]
     {% endif %}
     {% if insecure %}
     #[deprecated(note = "Insecure cryptography, do not use in production")]
@@ -57,9 +65,11 @@ pub const PQCLEAN_{{ NS_NAME }}_CRYPTO_PUBLICKEYBYTES: usize = {{ metadata['leng
     pub const PQCLEAN_{{ NS_NAME }}_CRYPTO_BYTES: usize = {{ metadata['length-shared-secret'] }};
 {% else %}
     {% if implementation == 'avx2' or implementation == 'avx' %}
-    #[cfg(enable_avx2)]
+    #[cfg(enable_x86_avx2)]
     {% elif implementation == 'aesni' %}
-    #[cfg(enable_aes)]
+    #[cfg(enable_x86_aes)]
+    {% elif implementation == 'aarch64' %}
+    #[cfg(enable_aarch64_neon)]
     {% endif %}
     {% if insecure %}
     #[deprecated(note = "Insecure cryptography, do not use in production")]
@@ -75,35 +85,43 @@ pub const PQCLEAN_{{ NS_NAME }}_CRYPTO_PUBLICKEYBYTES: usize = {{ metadata['leng
 {% set NS_NAME = [scheme.name|namespaceize, implementation|namespaceize]|join('_') %}
 
 {% if implementation == 'avx2' or implementation == 'avx' %}
-#[cfg(enable_avx2)]
+#[cfg(enable_x86_avx2)]
 {% elif implementation == 'aesni' %}
-#[cfg(enable_aes)]
+#[cfg(enable_x86_aes)]
+{% elif implementation == 'aarch64' %}
+#[cfg(enable_aarch64_neon)]
 {% endif %}
 #[link(name = "{{ scheme.name }}_{{ implementation }}")]
 extern "C" {
 {% if type == "kem" %}
     {% if implementation == 'avx2' or implementation == 'avx' %}
-    #[cfg(enable_avx2)]
+    #[cfg(enable_x86_avx2)]
     {% elif implementation == 'aesni' %}
-    #[cfg(enable_aes)]
+    #[cfg(enable_x86_aes)]
+    {% elif implementation == 'aarch64' %}
+    #[cfg(enable_aarch64_neon)]
     {% endif %}
     {% if insecure %}
     #[deprecated(note = "Insecure cryptography, do not use in production")]
     {% endif %}
         pub fn PQCLEAN_{{ NS_NAME }}_crypto_kem_keypair(pk: *mut u8, sk: *mut u8) -> c_int;
     {% if implementation == 'avx2' or implementation == 'avx' %}
-    #[cfg(enable_avx2)]
+    #[cfg(enable_x86_avx2)]
     {% elif implementation == 'aesni' %}
-    #[cfg(enable_aes)]
+    #[cfg(enable_x86_aes)]
+    {% elif implementation == 'aarch64' %}
+    #[cfg(enable_aarch64_neon)]
     {% endif %}
     {% if insecure %}
     #[deprecated(note = "Insecure cryptography, do not use in production")]
     {% endif %}
         pub fn PQCLEAN_{{ NS_NAME }}_crypto_kem_enc(ct: *mut u8, ss: *mut u8, pk: *const u8) -> c_int;
     {% if implementation == 'avx2' or implementation == 'avx' %}
-    #[cfg(enable_avx2)]
+    #[cfg(enable_x86_avx2)]
     {% elif implementation == 'aesni' %}
-    #[cfg(enable_aes)]
+    #[cfg(enable_x86_aes)]
+    {% elif implementation == 'aarch64' %}
+    #[cfg(enable_aarch64_neon)]
     {% endif %}
     {% if insecure %}
     #[deprecated(note = "Insecure cryptography, do not use in production")]
@@ -115,45 +133,55 @@ extern "C" {
         ) -> c_int;
 {% else %}
     {% if implementation == 'avx2' or implementation == 'avx' %}
-    #[cfg(enable_avx2)]
+    #[cfg(enable_x86_avx2)]
     {% elif implementation == 'aesni' %}
-    #[cfg(enable_aes)]
+    #[cfg(enable_x86_aes)]
+    {% elif implementation == 'aarch64' %}
+    #[cfg(enable_aarch64_neon)]
     {% endif %}
     {% if insecure %}
     #[deprecated(note = "Insecure cryptography, do not use in production")]
     {% endif %}
         pub fn PQCLEAN_{{ NS_NAME }}_crypto_sign_keypair(pk: *mut u8, sk: *mut u8) -> c_int;
     {% if implementation == 'avx2' or implementation == 'avx' %}
-    #[cfg(enable_avx2)]
+    #[cfg(enable_x86_avx2)]
     {% elif implementation == 'aesni' %}
-    #[cfg(enable_aes)]
+    #[cfg(enable_x86_aes)]
+    {% elif implementation == 'aarch64' %}
+    #[cfg(enable_aarch64_neon)]
     {% endif %}
     {% if insecure %}
     #[deprecated(note = "Insecure cryptography, do not use in production")]
     {% endif %}
         pub fn PQCLEAN_{{ NS_NAME }}_crypto_sign(sm: *mut u8, smlen: *mut usize, msg: *const u8, len: usize, sk: *const u8) -> c_int;
     {% if implementation == 'avx2' or implementation == 'avx' %}
-    #[cfg(enable_avx2)]
+    #[cfg(enable_x86_avx2)]
     {% elif implementation == 'aesni' %}
-    #[cfg(enable_aes)]
+    #[cfg(enable_x86_aes)]
+    {% elif implementation == 'aarch64' %}
+    #[cfg(enable_aarch64_neon)]
     {% endif %}
     {% if insecure %}
     #[deprecated(note = "Insecure cryptography, do not use in production")]
     {% endif %}
         pub fn PQCLEAN_{{ NS_NAME }}_crypto_sign_open(m: *mut u8, mlen: *mut usize, sm: *const u8, smlen: usize, pk: *const u8) -> c_int;
     {% if implementation == 'avx2' or implementation == 'avx' %}
-    #[cfg(enable_avx2)]
+    #[cfg(enable_x86_avx2)]
     {% elif implementation == 'aesni' %}
-    #[cfg(enable_aes)]
+    #[cfg(enable_x86_aes)]
+    {% elif implementation == 'aarch64' %}
+    #[cfg(enable_aarch64_neon)]
     {% endif %}
     {% if insecure %}
     #[deprecated(note = "Insecure cryptography, do not use in production")]
     {% endif %}
         pub fn PQCLEAN_{{ NS_NAME }}_crypto_sign_signature(sig: *mut u8, siglen: *mut usize, m: *const u8, mlen: usize, sk: *const u8) -> c_int;
     {% if implementation == 'avx2' or implementation == 'avx' %}
-    #[cfg(enable_avx2)]
+    #[cfg(enable_x86_avx2)]
     {% elif implementation == 'aesni' %}
-    #[cfg(enable_aes)]
+    #[cfg(enable_x86_aes)]
+    {% elif implementation == 'aarch64' %}
+    #[cfg(enable_aarch64_neon)]
     {% endif %}
     {% if insecure %}
     #[deprecated(note = "Insecure cryptography, do not use in production")]
@@ -170,9 +198,11 @@ extern "C" {
 {% set NS_NAME = [scheme.name|namespaceize, implementation|namespaceize]|join('_') %}
 
 {% if implementation == 'avx2' or implementation == 'avx' %}
-#[cfg(all(test, enable_avx2, feature = "avx2"))]
+#[cfg(all(test, enable_x86_avx2, feature = "avx2"))]
 {% elif implementation == 'aesni' %}
-#[cfg(all(test, enable_aes, feature = "aes"))]
+#[cfg(all(test, enable_x86_aes, feature = "aes"))]
+{% elif implementation == 'aarch64' %}
+#[cfg(all(test, enable_aarch64_neon, feature = "neon"))]
 {% else %}
 #[cfg(test)]
 {% endif %}

--- a/pqcrypto-template/scheme/src/scheme.rs.j2
+++ b/pqcrypto-template/scheme/src/scheme.rs.j2
@@ -30,8 +30,9 @@
 // This file is generated.
 
 {% set globals = namespace() %}
-{% set globals.have_avx2 = False %}
-{% set globals.have_aes = False %}
+{% set globals.x86_aes = False %}
+{% set globals.x86_avx2 = False %}
+{% set globals.aarch64_neon = False %}
 
 #[cfg(feature = "serialization")]
 use serde::{Deserialize, Serialize};
@@ -101,14 +102,20 @@ macro_rules! simple_struct {
 
 {% set NS_NAME = [scheme.name|namespaceize, scheme.implementations[0]|namespaceize]|join('_') %}
 {% if 'avx2' in scheme.implementations %}
-{% set globals.have_avx2 = True %}
+{% set globals.x86_avx2 = True %}
 {% set AVX2_NAME = [scheme.name|namespaceize, 'avx2'|namespaceize]|join('_') %}
-{% elif 'avx' in scheme.implementations %}
-{% set globals.have_avx2 = True %}
+{% endif %}
+{% if 'avx' in scheme.implementations %}
+{% set globals.x86_avx2 = True %}
 {% set AVX2_NAME = [scheme.name|namespaceize, 'avx'|namespaceize]|join('_') %}
-{% elif 'aesni' in scheme.implementations %}
-{% set globals.have_aes = True %}
+{% endif %}
+{% if 'aesni' in scheme.implementations %}
+{% set globals.x86_aes = True %}
 {% set AES_NAME = [scheme.name|namespaceize, 'aesni'|namespaceize]|join('_') %}
+{% endif %}
+{% if 'aarch64' in scheme.implementations %}
+{% set globals.aarch64_neon = True %}
+{% set AARCH64_NAME = [scheme.name|namespaceize, 'aarch64'|namespaceize]|join('_') %}
 {% endif %}
 
 simple_struct!(PublicKey, ffi::PQCLEAN_{{ NS_NAME }}_CRYPTO_PUBLICKEYBYTES);
@@ -210,7 +217,7 @@ pub const fn shared_secret_bytes() -> usize {
 pub const fn signature_bytes() -> usize {
     ffi::PQCLEAN_{{ NS_NAME }}_CRYPTO_BYTES
 }
-{% endif %}
+{% endif %} {# KEM or SIGN #}
 
 macro_rules! gen_keypair {
     ($variant:ident) => {
@@ -231,8 +238,8 @@ macro_rules! gen_keypair {
 #[deprecated(note = "Insecure cryptography, do not use in production")]
 {% endif %}
 pub fn keypair() -> (PublicKey, SecretKey) {
-    {% if globals.have_avx2 %}
-    #[cfg(all(enable_avx2, feature = "avx2"))]
+    {% if globals.x86_avx2 %}
+    #[cfg(all(enable_x86_avx2, feature = "avx2"))]
     {
         if std::is_x86_feature_detected!("avx2") {
             {% if type == "kem" %}
@@ -243,14 +250,29 @@ pub fn keypair() -> (PublicKey, SecretKey) {
         }
     }
     {% endif %}
-    {% if globals.have_aes %}
-    #[cfg(all(enable_aes, feature = "aes"))]
+    {% if globals.x86_aes %}
+    #[cfg(all(enable_x86_aes, feature = "aes"))]
     {
         if std::is_x86_feature_detected!("aes") {
             {% if type == "kem" %}
             return gen_keypair!(PQCLEAN_{{ AES_NAME }}_crypto_kem_keypair);
             {% else %}
             return gen_keypair!(PQCLEAN_{{ AES_NAME }}_crypto_sign_keypair);
+            {% endif %}
+        }
+    }
+    {% endif %}
+    {% if globals.aarch64_neon %}
+    #[cfg(all(enable_aarch64_neon, feature = "neon"))]
+    {
+        // always use AArch64 code, when target is detected as all AArch64 targets have NEON
+        // support, and std::is_aarch64_feature_detected!("neon") works only with Rust nightly at
+        // the moment
+        if true {
+            {% if type == "kem" %}
+            return gen_keypair!(PQCLEAN_{{ AARCH64_NAME }}_crypto_kem_keypair);
+            {% else %}
+            return gen_keypair!(PQCLEAN_{{ AARCH64_NAME }}_crypto_sign_keypair);
             {% endif %}
         }
     }
@@ -285,19 +307,27 @@ macro_rules! encap {
 #[deprecated(note = "Insecure cryptography, do not use in production")]
 {% endif %}
 pub fn encapsulate(pk: &PublicKey) -> (SharedSecret, Ciphertext) {
-    {% if globals.have_avx2 %}
-    #[cfg(all(enable_avx2, feature = "avx2"))]
+    {% if globals.x86_avx2 %}
+    #[cfg(all(enable_x86_avx2, feature = "avx2"))]
     {
         if std::is_x86_feature_detected!("avx2") {
             return encap!(PQCLEAN_{{ AVX2_NAME }}_crypto_kem_enc, pk);
         }
     }
     {% endif %}
-    {% if globals.have_aes %}
-    #[cfg(all(enable_aes, feature = "aes"))]
+    {% if globals.x86_aes %}
+    #[cfg(all(enable_x86_aes, feature = "aes"))]
     {
         if std::is_x86_feature_detected!("aes") {
             return encap!(PQCLEAN_{{ AES_NAME }}_crypto_kem_enc, pk);
+        }
+    }
+    {% endif %}
+    {% if globals.aarch64_neon %}
+    #[cfg(all(enable_aarch64_neon, feature = "neon"))]
+    {
+        if true {
+            return encap!(PQCLEAN_{{ AARCH64_NAME }}_crypto_kem_enc, pk);
         }
     }
     {% endif %}
@@ -328,19 +358,27 @@ macro_rules! decap {
 #[deprecated(note = "Insecure cryptography, do not use in production")]
 {% endif %}
 pub fn decapsulate(ct: &Ciphertext, sk: &SecretKey) -> SharedSecret {
-    {% if globals.have_avx2 %}
-    #[cfg(all(enable_avx2, feature = "avx2"))]
+    {% if globals.x86_avx2 %}
+    #[cfg(all(enable_x86_avx2, feature = "avx2"))]
     {
         if std::is_x86_feature_detected!("avx2") {
             return decap!(PQCLEAN_{{ AVX2_NAME }}_crypto_kem_dec, ct, sk);
         }
     }
     {% endif %}
-    {% if globals.have_aes %}
-    #[cfg(all(enable_aes, feature = "aes"))]
+    {% if globals.x86_aes %}
+    #[cfg(all(enable_x86_aes, feature = "aes"))]
     {
         if std::is_x86_feature_detected!("aes") {
             return decap!(PQCLEAN_{{ AES_NAME }}_crypto_kem_dec, ct, sk);
+        }
+    }
+    {% endif %}
+    {% if globals.aarch64_neon %}
+    #[cfg(all(enable_aarch64_neon, feature = "neon"))]
+    {
+        if true {
+            return decap!(PQCLEAN_{{ AARCH64_NAME }}_crypto_kem_dec, ct, sk);
         }
     }
     {% endif %}
@@ -378,19 +416,27 @@ macro_rules! gen_signature {
 #[deprecated(note = "Insecure cryptography, do not use in production")]
 {% endif %}
 pub fn sign(msg: &[u8], sk: &SecretKey) -> SignedMessage {
-    {% if globals.have_avx2 %}
-    #[cfg(all(enable_avx2, feature = "avx2"))]
+    {% if globals.x86_avx2 %}
+    #[cfg(all(enable_x86_avx2, feature = "avx2"))]
     {
         if std::is_x86_feature_detected!("avx2") {
             return gen_signature!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign, msg, sk);
         }
     }
     {% endif %}
-    {% if globals.have_aes %}
-    #[cfg(all(enable_aes, feature = "aes"))]
+    {% if globals.x86_aes %}
+    #[cfg(all(enable_x86_aes, feature = "aes"))]
     {
         if std::is_x86_feature_detected!("aes") {
             return gen_signature!(PQCLEAN_{{ AES_NAME }}_crypto_sign, msg, sk);
+        }
+    }
+    {% endif %}
+    {% if globals.aarch64_neon %}
+    #[cfg(all(enable_aarch64_neon, feature = "neon"))]
+    {
+        if true {
+            return gen_signature!(PQCLEAN_{{ AARCH64_NAME }}_crypto_sign, msg, sk);
         }
     }
     {% endif %}
@@ -430,19 +476,27 @@ pub fn open(
     sm: &SignedMessage,
     pk: &PublicKey
 ) -> core::result::Result<Vec<u8>,primitive::VerificationError> {
-    {% if globals.have_avx2 %}
-    #[cfg(all(enable_avx2, feature = "avx2"))]
+    {% if globals.x86_avx2 %}
+    #[cfg(all(enable_x86_avx2, feature = "avx2"))]
     {
         if std::is_x86_feature_detected!("avx2") {
             return open_signed!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign_open, sm, pk);
         }
     }
     {% endif %}
-    {% if globals.have_aes %}
-    #[cfg(all(enable_aes, feature = "aes"))]
+    {% if globals.x86_aes %}
+    #[cfg(all(enable_x86_aes, feature = "aes"))]
     {
         if std::is_x86_feature_detected!("aes") {
             return open_signed!(PQCLEAN_{{ AES_NAME }}_crypto_sign_open, sm, pk);
+        }
+    }
+    {% endif %}
+    {% if globals.aarch64_neon %}
+    #[cfg(all(enable_aarch64_neon, feature = "neon"))]
+    {
+        if true {
+            return open_signed!(PQCLEAN_{{ AARCH64_NAME }}_crypto_sign_open, sm, pk);
         }
     }
     {% endif %}
@@ -472,19 +526,27 @@ macro_rules! detached_signature {
 {% endif %}
 /// Create a detached signature on the message
 pub fn detached_sign(msg: &[u8], sk: &SecretKey) -> DetachedSignature {
-    {% if globals.have_avx2 %}
-    #[cfg(all(enable_avx2, feature = "avx2"))]
+    {% if globals.x86_avx2 %}
+    #[cfg(all(enable_x86_avx2, feature = "avx2"))]
     {
         if std::is_x86_feature_detected!("avx2") {
             return detached_signature!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign_signature, msg, sk);
         }
     }
     {% endif %}
-    {% if globals.have_aes %}
-    #[cfg(all(enable_aes, feature = "aes"))]
+    {% if globals.x86_aes %}
+    #[cfg(all(enable_x86_aes, feature = "aes"))]
     {
         if std::is_x86_feature_detected!("aes") {
             return detached_signature!(PQCLEAN_{{ AES_NAME }}_crypto_sign_signature, msg, sk);
+        }
+    }
+    {% endif %}
+    {% if globals.aarch64_neon %}
+    #[cfg(all(enable_aarch64_neon, feature = "neon"))]
+    {
+        if true {
+            return detached_signature!(PQCLEAN_{{ AARCH64_NAME }}_crypto_sign_signature, msg, sk);
         }
     }
     {% endif %}
@@ -517,19 +579,27 @@ macro_rules! verify_detached_sig {
 #[deprecated(note = "Insecure cryptography, do not use in production")]
 {% endif %}
 pub fn verify_detached_signature(sig: &DetachedSignature, msg: &[u8], pk: &PublicKey) -> core::result::Result<(), primitive::VerificationError> {
-    {% if globals.have_avx2 %}
-    #[cfg(all(enable_avx2, feature = "avx2"))]
+    {% if globals.x86_avx2 %}
+    #[cfg(all(enable_x86_avx2, feature = "avx2"))]
     {
         if std::is_x86_feature_detected!("avx2") {
             return verify_detached_sig!(PQCLEAN_{{ AVX2_NAME }}_crypto_sign_verify, sig, msg, pk);
         }
     }
     {% endif %}
-    {% if globals.have_aes %}
-    #[cfg(all(enable_aes, feature = "aes"))]
+    {% if globals.x86_aes %}
+    #[cfg(all(enable_x86_aes, feature = "aes"))]
     {
         if std::is_x86_feature_detected!("aes") {
             return verify_detached_sig!(PQCLEAN_{{ AES_NAME }}_crypto_sign_verify, sig, msg, pk);
+        }
+    }
+    {% endif %}
+    {% if globals.aarch64_neon %}
+    #[cfg(all(enable_aarch64_neon, feature = "neon"))]
+    {
+        if true {
+            return verify_detached_sig!(PQCLEAN_{{ AARCH64_NAME }}_crypto_sign_verify, sig, msg, pk);
         }
     }
     {% endif %}


### PR DESCRIPTION
Hi Thom,
this PR adds support for AArch64 builds and changes the naming scheme of some variables for the x86 builds. The adjustment reflects now which architecture and which feature is selected. There is at the moment no suitable runtime detection (see template scheme.rs.js) for Neon support, with Rust nightly it is possible, but I think it is not really needed, as AArch64 supports the Neon instructions out of the box (see also the deletion in cpufeatures by tarcieri https://github.com/RustCrypto/utils/pull/406/commits/45a39900dd5a6788643ed9c808fec52994692496).
This change was tested on my RaspberryPi 4 and all tests were successful.