### PR TITLE
fixed canonicalisation of include path in windows

### DIFF
--- a/pqcrypto-internals/Cargo.toml
+++ b/pqcrypto-internals/Cargo.toml
@@ -11,6 +11,7 @@ links = "pqcrypto_internals"
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }
+dunce = "1.0.2"
 
 [dependencies]
 getrandom = "0.2"

--- a/pqcrypto-internals/build.rs
+++ b/pqcrypto-internals/build.rs
@@ -1,10 +1,11 @@
 extern crate cc;
+extern crate dunce;
 
 use std::env;
 use std::path::Path;
 
 fn main() {
-    let includepath = Path::new("include").canonicalize().unwrap();
+    let includepath = dunce::canonicalize(Path::new("include")).unwrap();
     println!("cargo:includepath={}", includepath.to_str().unwrap());
 
     let cfiledir = Path::new("cfiles");


### PR DESCRIPTION
On windows `Path::canonacalize` adds a `\\?` in front.

Fixed by using the `dunce` crate: https://stackoverflow.com/questions/50322817/how-do-i-remove-the-prefix-from-a-canonical-windows-path