### PR TITLE
build.rs: Fix target vs host confusion

### DIFF
--- a/pqcrypto-classicmceliece/build.rs
+++ b/pqcrypto-classicmceliece/build.rs
@@ -82,7 +82,8 @@ macro_rules! build_avx {
         }
 
         let scheme_files = glob::glob(target_dir.join("*.[csS]").to_str().unwrap()).unwrap();
-        if cfg!(target_env = "msvc") {
+        let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+        if target_env == "msvc" {
             builder.flag("/arch:AVX2");
         } else {
             builder

--- a/pqcrypto-dilithium/build.rs
+++ b/pqcrypto-dilithium/build.rs
@@ -54,7 +54,8 @@ macro_rules! build_avx2 {
         }
 
         let scheme_files = glob::glob(target_dir.join("*.[csS]").to_str().unwrap()).unwrap();
-        if cfg!(target_env = "msvc") {
+        let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+        if target_env == "msvc" {
             builder.flag("/arch:AVX2");
         } else {
             builder

--- a/pqcrypto-falcon/build.rs
+++ b/pqcrypto-falcon/build.rs
@@ -54,7 +54,8 @@ macro_rules! build_avx2 {
         }
 
         let scheme_files = glob::glob(target_dir.join("*.[csS]").to_str().unwrap()).unwrap();
-        if cfg!(target_env = "msvc") {
+        let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+        if target_env == "msvc" {
             builder.flag("/arch:AVX2");
         } else {
             builder

--- a/pqcrypto-internals/build.rs
+++ b/pqcrypto-internals/build.rs
@@ -42,8 +42,8 @@ fn main() {
             builder.flag(format!("--sysroot={}", wasi_sdk_path).as_str());
         }
 
-        let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
-        if target_os == "windows" {
+        let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+        if target_env == "msvc" {
             builder.flag("/arch:AVX2");
         } else {
             builder.flag("-mavx2");

--- a/pqcrypto-kyber/build.rs
+++ b/pqcrypto-kyber/build.rs
@@ -52,7 +52,8 @@ macro_rules! build_avx2 {
         }
 
         let scheme_files = glob::glob(target_dir.join("*.[csS]").to_str().unwrap()).unwrap();
-        if cfg!(target_env = "msvc") {
+        let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+        if target_env == "msvc" {
             builder.flag("/arch:AVX2");
         } else {
             builder

--- a/pqcrypto-ntru/build.rs
+++ b/pqcrypto-ntru/build.rs
@@ -52,7 +52,8 @@ macro_rules! build_avx2 {
         }
 
         let scheme_files = glob::glob(target_dir.join("*.[csS]").to_str().unwrap()).unwrap();
-        if cfg!(target_env = "msvc") {
+        let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+        if target_env == "msvc" {
             builder.flag("/arch:AVX2");
         } else {
             builder

--- a/pqcrypto-ntruprime/build.rs
+++ b/pqcrypto-ntruprime/build.rs
@@ -52,7 +52,8 @@ macro_rules! build_avx2 {
         }
 
         let scheme_files = glob::glob(target_dir.join("*.[csS]").to_str().unwrap()).unwrap();
-        if cfg!(target_env = "msvc") {
+        let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+        if target_env == "msvc" {
             builder.flag("/arch:AVX2");
         } else {
             builder

--- a/pqcrypto-saber/build.rs
+++ b/pqcrypto-saber/build.rs
@@ -52,7 +52,8 @@ macro_rules! build_avx2 {
         }
 
         let scheme_files = glob::glob(target_dir.join("*.[csS]").to_str().unwrap()).unwrap();
-        if cfg!(target_env = "msvc") {
+        let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+        if target_env == "msvc" {
             builder.flag("/arch:AVX2");
         } else {
             builder

--- a/pqcrypto-sphincsplus/build.rs
+++ b/pqcrypto-sphincsplus/build.rs
@@ -54,7 +54,8 @@ macro_rules! build_aesni {
         }
 
         let scheme_files = glob::glob(target_dir.join("*.[csS]").to_str().unwrap()).unwrap();
-        if cfg!(target_env = "msvc") {
+        let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+        if target_env == "msvc" {
             builder.flag("/arch:AVX2");
         } else {
             builder.flag("-maes");
@@ -91,7 +92,8 @@ macro_rules! build_avx2 {
         }
 
         let scheme_files = glob::glob(target_dir.join("*.[csS]").to_str().unwrap()).unwrap();
-        if cfg!(target_env = "msvc") {
+        let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+        if target_env == "msvc" {
             builder.flag("/arch:AVX2");
         } else {
             builder

--- a/pqcrypto-template/scheme/build.rs.j2
+++ b/pqcrypto-template/scheme/build.rs.j2
@@ -29,7 +29,8 @@ macro_rules! build_{{ implementation }} {
         {% if implementation == 'avx2' or implementation == 'avx' %}
         {% set globals.x86_avx2 = True %}
         let scheme_files = glob::glob(target_dir.join("*.[csS]").to_str().unwrap()).unwrap();
-        if cfg!(target_env = "msvc") {
+        let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+        if target_env == "msvc" {
             builder.flag("/arch:AVX2");
         } else {
             builder
@@ -43,7 +44,8 @@ macro_rules! build_{{ implementation }} {
         {% elif implementation == 'aesni' %}
         {% set globals.x86_aes = True %}
         let scheme_files = glob::glob(target_dir.join("*.[csS]").to_str().unwrap()).unwrap();
-        if cfg!(target_env = "msvc") {
+        let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+        if target_env == "msvc" {
             builder.flag("/arch:AVX2");
         } else {
             builder


### PR DESCRIPTION
Since the build.rs is compiled and executed on the host architecture,
cfg!(target_ ...) in build.rs check for the host architecture, but not
the target architecture. If host and target architecture both use
gcc-ish platforms or MSVC, the checks based on cfg!(target_*) have the
desired effect. However, when one architecture accepts gcc flags, but
the other doesn't, builds break.

This issue was observed when trying to cross compile to
x86_64-pc-windows-gnu via cargo-cross:
```
C:\Users\runneradmin\.cargo\bin\cargo.exe check --all --bins --tests --target x86_64-pc-windows-gnu
    Updating crates.io index
 Downloading crates ...
  Downloaded aes v0.7.5
  Downloaded darling_core v0.10.2
  Downloaded lazy_static v1.4.0
  Downloaded opaque-debug v0.3.0
  Downloaded num-derive v0.3.3
  Downloaded subtle v2.4.1
  Downloaded winapi-util v0.1.5
  Downloaded clear_on_drop v0.2.5
  Downloaded rand v0.7.3
  Downloaded zeroize_derive v1.3.2
  Downloaded digest v0.9.0
  Downloaded humantime v1.3.0
  Downloaded keccak v0.1.0
  Downloaded env_logger v0.7.1
  Downloaded cipher v0.3.0
  Downloaded block-modes v0.8.1
  Downloaded des v0.7.0
  Downloaded rand_chacha v0.3.1
  Downloaded num-iter v0.1.42
  Downloaded pqcrypto-traits v0.3.4
  Downloaded pretty_assertions v0.7.2
  Downloaded sha3 v0.9.1
  Downloaded pretty_env_logger v0.4.0
  Downloaded regex v1.5.5
  Downloaded serde_derive v1.0.136
  Downloaded serde-big-array v0.3.3
  Downloaded twofish v0.6.0
  Downloaded spki v0.4.1
  Downloaded zeroize v1.4.3
  Downloaded x25519-dalek v1.1.1
  Downloaded sha2 v0.9.9
  Downloaded picnic-sys v3.0.14
  Downloaded termcolor v1.1.3
  Downloaded winapi v0.3.9
  Downloaded winapi-x86_64-pc-windows-gnu v0.4.0
  Downloaded rsa v0.5.0
  Downloaded ripemd160 v0.9.1
  Downloaded safemem v0.3.3
  Downloaded rand_xorshift v0.3.0
  Downloaded pkcs8 v0.7.6
  Downloaded pkcs1 v0.2.4
  Downloaded pqcrypto-kyber v0.7.5
  Downloaded pem-rfc7468 v0.2.4
  Downloaded pqcrypto-internals v0.2.4
  Downloaded picnic-bindings v0.4.2
  Downloaded num-bigint-dig v0.7.0
  Downloaded der v0.4.5
  Downloaded bitfield v0.13.2
  Downloaded darling_macro v0.10.2
  Downloaded cast5 v0.10.0
  Downloaded crypto-bigint v0.2.11
  Downloaded const-oid v0.6.2
  Downloaded buf_redux v0.8.4
  Downloaded block-padding v0.2.1
  Downloaded base64ct v1.1.1
  Downloaded autocfg v0.1.8
  Downloaded version_check v0.1.5
  Downloaded sha-1 v0.9.8
  Downloaded paste v1.0.7
  Downloaded output_vt100 v0.1.3
  Downloaded derive_builder_core v0.9.0
  Downloaded crc24 v0.1.6
  Downloaded circular v0.3.0
  Downloaded cfb-mode v0.7.1
  Downloaded blowfish v0.8.0
  Downloaded getrandom v0.1.16
  Downloaded fnv v1.0.7
  Downloaded crc32fast v1.3.2
  Downloaded cpufeatures v0.2.2
  Downloaded chrono v0.4.19
  Downloaded cfg-if v1.0.0
  Downloaded cc v1.0.73
  Downloaded byteorder v1.4.3
  Downloaded block-buffer v0.9.0
  Downloaded base64 v0.13.0
  Downloaded autocfg v1.1.0
  Downloaded atty v0.2.14
  Downloaded ansi_term v0.12.1
  Downloaded aho-corasick v0.7.18
  Downloaded adler v1.0.2
  Downloaded version_check v0.9.4
  Downloaded unicode-xid v0.2.2
  Downloaded typenum v1.15.0
  Downloaded time v0.1.43
  Downloaded thiserror-impl v1.0.30
  Downloaded thiserror v1.0.30
  Downloaded synstructure v0.12.6
  Downloaded syn v1.0.91
  Downloaded strsim v0.9.3
  Downloaded spin v0.5.2
  Downloaded smallvec v1.8.0
  Downloaded signature v1.5.0
  Downloaded serde_json v1.0.79
  Downloaded serde v1.0.136
  Downloaded ryu v1.0.9
  Downloaded regex-syntax v0.6.25
  Downloaded rand_core v0.6.3
  Downloaded rand_core v0.5.1
  Downloaded rand_chacha v0.2.2
  Downloaded rand v0.8.5
  Downloaded quote v1.0.18
  Downloaded quick-error v1.2.3
  Downloaded proc-macro2 v1.0.37
  Downloaded ppv-lite86 v0.2.16
  Downloaded pkg-config v0.3.25
  Downloaded nom v4.2.3
  Downloaded miniz_oxide v0.5.1
  Downloaded md-5 v0.9.1
  Downloaded hex-literal v0.3.4
  Downloaded ed25519 v1.4.1
  Downloaded dunce v1.0.2
  Downloaded derive_builder v0.9.0
  Downloaded num-traits v0.2.14
  Downloaded num-integer v0.1.44
  Downloaded memchr v2.4.1
  Downloaded log v0.4.16
  Downloaded libm v0.2.2
  Downloaded libc v0.2.124
  Downloaded jobserver v0.1.24
  Downloaded itoa v1.0.1
  Downloaded ident_case v1.0.1
  Downloaded hex v0.4.3
  Downloaded glob v0.3.0
  Downloaded getrandom v0.2.6
  Downloaded generic-array v0.14.5
  Downloaded flate2 v1.0.23
  Downloaded ed25519-dalek v1.0.1
  Downloaded diff v0.1.12
  Downloaded curve25519-dalek v3.2.0
  Downloaded darling v0.10.2
  Downloaded ctor v0.1.22
   Compiling proc-macro2 v1.0.37
    Checking cfg-if v1.0.0
   Compiling unicode-xid v0.2.2
   Compiling typenum v1.15.0
   Compiling version_check v0.9.4
   Compiling syn v1.0.91
   Compiling autocfg v1.1.0
   Compiling jobserver v0.1.24
   Compiling winapi-x86_64-pc-windows-gnu v0.4.0
   Compiling winapi v0.3.9
    Checking opaque-debug v0.3.0
    Checking subtle v2.4.1
    Checking byteorder v1.4.3
   Compiling serde_derive v1.0.136
   Compiling libc v0.2.124
    Checking block-padding v0.2.1
   Compiling serde v1.0.136
   Compiling memchr v2.4.1
   Compiling getrandom v0.1.16
   Compiling libm v0.2.2
    Checking ppv-lite86 v0.2.16
   Compiling dunce v1.0.2
   Compiling fnv v1.0.7
    Checking const-oid v0.6.2
   Compiling strsim v0.9.3
   Compiling ident_case v1.0.1
   Compiling pkg-config v0.3.25
    Checking cpufeatures v0.2.2
    Checking base64ct v1.1.1
   Compiling log v0.4.16
    Checking spin v0.5.2
   Compiling glob v0.3.0
    Checking signature v1.5.0
   Compiling crc32fast v1.3.2
   Compiling version_check v0.1.5
    Checking regex-syntax v0.6.25
    Checking adler v1.0.2
    Checking quick-error v1.2.3
    Checking smallvec v1.8.0
   Compiling crc24 v0.1.6
   Compiling derive_builder v0.9.0
    Checking safemem v0.3.3
    Checking keccak v0.1.0
   Compiling paste v1.0.7
   Compiling serde_json v1.0.79
    Checking pqcrypto-traits v0.3.4
    Checking base64 v0.13.0
    Checking circular v0.3.0
    Checking diff v0.1.12
    Checking bitfield v0.13.2
    Checking hex v0.4.3
    Checking itoa v1.0.1
    Checking ryu v1.0.9
   Compiling hex-literal v0.3.4
    Checking getrandom v0.2.6
   Compiling generic-array v0.14.5
   Compiling autocfg v0.1.8
   Compiling cc v1.0.73
   Compiling num-traits v0.2.14
   Compiling num-integer v0.1.44
   Compiling num-iter v0.1.42
    Checking pem-rfc7468 v0.2.4
    Checking lazy_static v1.4.0
    Checking ed25519 v1.4.1
   Compiling nom v4.2.3
    Checking miniz_oxide v0.5.1
    Checking humantime v1.3.0
    Checking rand_core v0.6.3
   Compiling num-bigint-dig v0.7.0
    Checking rand_chacha v0.3.1
    Checking rand_xorshift v0.3.0
   Compiling quote v1.0.18
   Compiling pqcrypto-internals v0.2.4
   Compiling picnic-sys v3.0.14
   Compiling clear_on_drop v0.2.5
   Compiling pqcrypto-kyber v0.7.5
    Checking rand_core v0.5.1
    Checking aho-corasick v0.7.18
    Checking buf_redux v0.8.4
    Checking flate2 v1.0.23
    Checking rand v0.8.5
    Checking digest v0.9.0
    Checking cipher v0.3.0
    Checking block-buffer v0.9.0
    Checking crypto-bigint v0.2.11
    Checking rand_chacha v0.2.2
    Checking regex v1.5.5
    Checking winapi-util v0.1.5
    Checking atty v0.2.14
    Checking time v0.1.43
    Checking output_vt100 v0.1.3
    Checking ansi_term v0.12.1
    Checking block-modes v0.8.1
    Checking twofish v0.6.0
    Checking blowfish v0.8.0
    Checking cfb-mode v0.7.1
    Checking cast5 v0.10.0
    Checking aes v0.7.5
    Checking des v0.7.0
    Checking sha2 v0.9.9
    Checking sha-1 v0.9.8
    Checking ripemd160 v0.9.1
    Checking md-5 v0.9.1
    Checking sha3 v0.9.1
   Compiling synstructure v0.12.6
   Compiling darling_core v0.10.2
    Checking der v0.4.5
    Checking rand v0.7.3
    Checking termcolor v1.1.3
    Checking chrono v0.4.19
   Compiling zeroize_derive v1.3.2
   Compiling thiserror-impl v1.0.30
   Compiling num-derive v0.3.3
   Compiling ctor v0.1.22
    Checking spki v0.4.1
    Checking env_logger v0.7.1
   Compiling darling_macro v0.10.2
    Checking zeroize v1.4.3
    Checking thiserror v1.0.30
    Checking pretty_assertions v0.7.2
    Checking pretty_env_logger v0.4.0
    Checking curve25519-dalek v3.2.0
    Checking pkcs1 v0.2.4
   Compiling darling v0.10.2
    Checking x25519-dalek v1.1.1
    Checking pkcs8 v0.7.6
   Compiling derive_builder_core v0.9.0
    Checking serde-big-array v0.3.3
    Checking ed25519-dalek v1.0.1
    Checking rsa v0.5.0
The following warnings were emitted during compilation:

warning: gcc.exe: error: /arch:AVX2: No such file or directory
Warning: gcc.exe: error: /arch:AVX2: No such file or directory
error: failed to run custom build command for `pqcrypto-internals v0.2.4`
Error: failed to run custom build command for `pqcrypto-internals v0.2.4`
Caused by:
  process didn't exit successfully: `D:\a\test-project\test-project\target\debug\build\pqcrypto-internals-fa25fb2de6096116\build-script-build` (exit code: 1)
  --- stdout
  cargo:includepath=C:\Users\runneradmin\.cargo\registry\src\github.com-1ecc6299db9ec823\pqcrypto-internals-0.2.4\include
  TARGET = Some("x86_64-pc-windows-gnu")
  OPT_LEVEL = Some("0")
  HOST = Some("x86_64-pc-windows-msvc")
  CC_x86_64-pc-windows-gnu = None
  CC_x86_64_pc_windows_gnu = None
  TARGET_CC = None
  CC = None
  CFLAGS_x86_64-pc-windows-gnu = None
  CFLAGS_x86_64_pc_windows_gnu = None
  TARGET_CFLAGS = None
  CFLAGS = None
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("true")
  CARGO_CFG_TARGET_FEATURE = Some("fxsr,sse,sse2")
  running: "gcc.exe" "-O0" "-ffunction-sections" "-fdata-sections" "-g" "-fno-omit-frame-pointer" "-m64" "-I" "C:\\Users\\runneradmin\\.cargo\\registry\\src\\github.com-1ecc6299db9ec823\\pqcrypto-internals-0.2.4\\include" "-Wall" "-Wextra" "-o" "D:\\a\\test-project\\test-project\\target\\x86_64-pc-windows-gnu\\debug\\build\\pqcrypto-internals-49d5b968eb9d3d95\\out\\cfiles\\fips202.o" "-c" "cfiles\\fips202.c"
  exit code: 0
  running: "gcc.exe" "-O0" "-ffunction-sections" "-fdata-sections" "-g" "-fno-omit-frame-pointer" "-m64" "-I" "C:\\Users\\runneradmin\\.cargo\\registry\\src\\github.com-1ecc6299db9ec823\\pqcrypto-internals-0.2.4\\include" "-Wall" "-Wextra" "-o" "D:\\a\\test-project\\test-project\\target\\x86_64-pc-windows-gnu\\debug\\build\\pqcrypto-internals-49d5b968eb9d3d95\\out\\cfiles\\aes.o" "-c" "cfiles\\aes.c"
  exit code: 0
  running: "gcc.exe" "-O0" "-ffunction-sections" "-fdata-sections" "-g" "-fno-omit-frame-pointer" "-m64" "-I" "C:\\Users\\runneradmin\\.cargo\\registry\\src\\github.com-1ecc6299db9ec823\\pqcrypto-internals-0.2.4\\include" "-Wall" "-Wextra" "-o" "D:\\a\\test-project\\test-project\\target\\x86_64-pc-windows-gnu\\debug\\build\\pqcrypto-internals-49d5b968eb9d3d95\\out\\cfiles\\sha2.o" "-c" "cfiles\\sha2.c"
  exit code: 0
  running: "gcc.exe" "-O0" "-ffunction-sections" "-fdata-sections" "-g" "-fno-omit-frame-pointer" "-m64" "-I" "C:\\Users\\runneradmin\\.cargo\\registry\\src\\github.com-1ecc6299db9ec823\\pqcrypto-internals-0.2.4\\include" "-Wall" "-Wextra" "-o" "D:\\a\\test-project\\test-project\\target\\x86_64-pc-windows-gnu\\debug\\build\\pqcrypto-internals-49d5b968eb9d3d95\\out\\cfiles\\nistseedexpander.o" "-c" "cfiles\\nistseedexpander.c"
  exit code: 0
  running: "gcc.exe" "-O0" "-ffunction-sections" "-fdata-sections" "-g" "-fno-omit-frame-pointer" "-m64" "-I" "C:\\Users\\runneradmin\\.cargo\\registry\\src\\github.com-1ecc6299db9ec823\\pqcrypto-internals-0.2.4\\include" "-Wall" "-Wextra" "-o" "D:\\a\\test-project\\test-project\\target\\x86_64-pc-windows-gnu\\debug\\build\\pqcrypto-internals-49d5b968eb9d3d95\\out\\cfiles\\sp800-185.o" "-c" "cfiles\\sp800-185.c"
  exit code: 0
  AR_x86_64-pc-windows-gnu = None
  AR_x86_64_pc_windows_gnu = None
  TARGET_AR = None
  AR = None
  CROSS_COMPILE = None
  running: "ar" "cq" "D:\\a\\test-project\\test-project\\target\\x86_64-pc-windows-gnu\\debug\\build\\pqcrypto-internals-49d5b968eb9d3d95\\out\\libpqclean_common.a" "D:\\a\\test-project\\test-project\\target\\x86_64-pc-windows-gnu\\debug\\build\\pqcrypto-internals-49d5b968eb9d3d95\\out\\cfiles\\fips202.o" "D:\\a\\test-project\\test-project\\target\\x86_64-pc-windows-gnu\\debug\\build\\pqcrypto-internals-49d5b968eb9d3d95\\out\\cfiles\\aes.o" "D:\\a\\test-project\\test-project\\target\\x86_64-pc-windows-gnu\\debug\\build\\pqcrypto-internals-49d5b968eb9d3d95\\out\\cfiles\\sha2.o" "D:\\a\\test-project\\test-project\\target\\x86_64-pc-windows-gnu\\debug\\build\\pqcrypto-internals-49d5b968eb9d3d95\\out\\cfiles\\nistseedexpander.o" "D:\\a\\test-project\\test-project\\target\\x86_64-pc-windows-gnu\\debug\\build\\pqcrypto-internals-49d5b968eb9d3d95\\out\\cfiles\\sp800-185.o"
  exit code: 0
  running: "ar" "s" "D:\\a\\test-project\\test-project\\target\\x86_64-pc-windows-gnu\\debug\\build\\pqcrypto-internals-49d5b968eb9d3d95\\out\\libpqclean_common.a"
  exit code: 0
  cargo:rustc-link-lib=static=pqclean_common
  cargo:rustc-link-search=native=D:\a\test-project\test-project\target\x86_64-pc-windows-gnu\debug\build\pqcrypto-internals-49d5b968eb9d3d95\out
  cargo:rustc-link-lib=pqclean_common
  TARGET = Some("x86_64-pc-windows-gnu")
  OPT_LEVEL = Some("0")
  HOST = Some("x86_64-pc-windows-msvc")
  CC_x86_64-pc-windows-gnu = None
  CC_x86_64_pc_windows_gnu = None
  TARGET_CC = None
  CC = None
  CFLAGS_x86_64-pc-windows-gnu = None
  CFLAGS_x86_64_pc_windows_gnu = None
  TARGET_CFLAGS = None
  CFLAGS = None
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("true")
  CARGO_CFG_TARGET_FEATURE = Some("fxsr,sse,sse2")
  running: "gcc.exe" "-O0" "-ffunction-sections" "-fdata-sections" "-g" "-fno-omit-frame-pointer" "-m64" "-Wall" "-Wextra" "/arch:AVX2" "-o" "D:\\a\\test-project\\test-project\\target\\x86_64-pc-windows-gnu\\debug\\build\\pqcrypto-internals-49d5b968eb9d3d95\\out\\cfiles\\keccak4x\\KeccakP-1600-times4-SIMD256.o" "-c" "cfiles\\keccak4x\\KeccakP-1600-times4-SIMD256.c"
  cargo:warning=gcc.exe: error: /arch:AVX2: No such file or directory
  exit code: 1

  --- stderr


  error occurred: Command "gcc.exe" "-O0" "-ffunction-sections" "-fdata-sections" "-g" "-fno-omit-frame-pointer" "-m64" "-Wall" "-Wextra" "/arch:AVX2" "-o" "D:\\a\\test-project\\test-project\\target\\x86_64-pc-windows-gnu\\debug\\build\\pqcrypto-internals-49d5b968eb9d3d95\\out\\cfiles\\keccak4x\\KeccakP-1600-times4-SIMD256.o" "-c" "cfiles\\keccak4x\\KeccakP-1600-times4-SIMD256.c" with args "gcc.exe" did not execute successfully (status code exit code: 1).


warning: build failed, waiting for other jobs to finish...
Warning: error: build failed
Error: The process 'C:\Users\runneradmin\.cargo\bin\cargo.exe' failed with exit code 101
```