### PR TITLE
Check `cryptographically-insecure` feature before running dependent tests

### DIFF
--- a/pqcrypto-rainbow/src/ffi.rs
+++ b/pqcrypto-rainbow/src/ffi.rs
@@ -437,7 +437,7 @@ extern "C" {
     ) -> c_int;
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "cryptographically-insecure"))]
 mod test_rainbowicircumzenithal_clean {
     use super::*;
     use alloc::vec;
@@ -559,7 +559,7 @@ mod test_rainbowicircumzenithal_clean {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "cryptographically-insecure"))]
 mod test_rainbowiclassic_clean {
     use super::*;
     use alloc::vec;
@@ -677,7 +677,7 @@ mod test_rainbowiclassic_clean {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "cryptographically-insecure"))]
 mod test_rainbowicompressed_clean {
     use super::*;
     use alloc::vec;
@@ -798,7 +798,7 @@ mod test_rainbowicompressed_clean {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "cryptographically-insecure"))]
 mod test_rainbowiiicircumzenithal_clean {
     use super::*;
     use alloc::vec;
@@ -922,7 +922,7 @@ mod test_rainbowiiicircumzenithal_clean {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "cryptographically-insecure"))]
 mod test_rainbowiiiclassic_clean {
     use super::*;
     use alloc::vec;
@@ -1043,7 +1043,7 @@ mod test_rainbowiiiclassic_clean {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "cryptographically-insecure"))]
 mod test_rainbowiiicompressed_clean {
     use super::*;
     use alloc::vec;
@@ -1164,7 +1164,7 @@ mod test_rainbowiiicompressed_clean {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "cryptographically-insecure"))]
 mod test_rainbowvcircumzenithal_clean {
     use super::*;
     use alloc::vec;
@@ -1286,7 +1286,7 @@ mod test_rainbowvcircumzenithal_clean {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "cryptographically-insecure"))]
 mod test_rainbowvclassic_clean {
     use super::*;
     use alloc::vec;
@@ -1404,7 +1404,7 @@ mod test_rainbowvclassic_clean {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "cryptographically-insecure"))]
 mod test_rainbowvcompressed_clean {
     use super::*;
     use alloc::vec;

--- a/pqcrypto-template/scheme/src/ffi.rs.j2
+++ b/pqcrypto-template/scheme/src/ffi.rs.j2
@@ -197,14 +197,26 @@ extern "C" {
 {% for implementation in scheme.implementations %}
 {% set NS_NAME = [scheme.name|namespaceize, implementation|namespaceize]|join('_') %}
 
-{% if implementation == 'avx2' or implementation == 'avx' %}
-#[cfg(all(test, enable_x86_avx2, feature = "avx2"))]
-{% elif implementation == 'aesni' %}
-#[cfg(all(test, enable_x86_aes, feature = "aes"))]
-{% elif implementation == 'aarch64' %}
-#[cfg(all(test, enable_aarch64_neon, feature = "neon"))]
+{% if insecure %}
+	{% if implementation == 'avx2' or implementation == 'avx' %}
+	#[cfg(all(test, enable_x86_avx2, feature = "avx2", feature = "cryptographically-insecure"))]
+	{% elif implementation == 'aesni' %}
+	#[cfg(all(test, enable_x86_aes, feature = "aes", feature = "cryptographically-insecure"))]
+	{% elif implementation == 'aarch64' %}
+	#[cfg(all(test, enable_aarch64_neon, feature = "neon", feature = "cryptographically-insecure"))]
+	{% else %}
+	#[cfg(all(test, feature = "cryptographically-insecure"))]
+	{% endif %}
 {% else %}
-#[cfg(test)]
+	{% if implementation == 'avx2' or implementation == 'avx' %}
+	#[cfg(all(test, enable_x86_avx2, feature = "avx2"))]
+	{% elif implementation == 'aesni' %}
+	#[cfg(all(test, enable_x86_aes, feature = "aes"))]
+	{% elif implementation == 'aarch64' %}
+	#[cfg(all(test, enable_aarch64_neon, feature = "neon"))]
+	{% else %}
+	#[cfg(test)]
+	{% endif %}
 {% endif %}
 mod test_{{ scheme.name|nameize }}_{{ implementation|nameize }} {
     use super::*;


### PR DESCRIPTION
This scopes tests dependent upon the `cryptographically-insecure` feature to be run only with the `cryptographically-insecure` feature is enabled.

This is a solution to issue #42 