### PR TITLE
Fix positions of arguments in error message

### DIFF
--- a/pqcrypto-traits/src/lib.rs
+++ b/pqcrypto-traits/src/lib.rs
@@ -29,7 +29,7 @@ impl core::fmt::Display for Error {
             } => write!(
                 f,
                 "error: {} expected {} bytes, got {}",
-                name, actual, expected
+                name, expected, actual
             ),
         }
     }


### PR DESCRIPTION
Hi Thom, here is just a quick fix for the positions for the arguments in the error message.