### PR TITLE
fix android build of pqcrypto-internals

### DIFF
--- a/pqcrypto-internals/build.rs
+++ b/pqcrypto-internals/build.rs
@@ -57,8 +57,12 @@ fn main() {
             .compile("keccak4x");
         println!("cargo:rustc-link-lib=keccak4x")
     } else if target_arch == "aarch64" && target_env != "msvc" {
+        if target_os == "android" {
+            builder.flag("-march=armv8-a");
+        } else {
+            builder.flag("-march=armv8-a+sha3");
+        }
         builder
-            .flag("-march=armv8-a+sha3")
             .file(cfiledir.join("keccak2x").join("fips202x2.c"))
             .file(cfiledir.join("keccak2x").join("feat.S"))
             .compile("keccak2x");


### PR DESCRIPTION
Fix the android build. Clang does not like the sha3 feature to be present in the arch flag when compiling for android.

The android build broke with https://github.com/rustpq/pqcrypto/pull/72/commits/e3b6f6657117f30f1f85a299e227ecdaa3a9c99c

See this error.
```
error occurred in cc-rs: Command LC_ALL="C" "/usr/local/lib/android/sdk/ndk/26.1.10909125/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android26-clang" "-O0" "-DANDROID" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "-Wall" "-Wextra" "-march=armv8-a+sha3" "-o" "/home/runner/work/tutanota/tutanota/tuta-sdk/rust/target/aarch64-linux-android/debug/build/pqcrypto-internals-99d56cd060658fdc/out/9cad35ea665b40e6-feat.o" "-c" "cfiles/keccak2x/feat.S" with args aarch64-linux-android26-clang did not execute successfully (status code exit status: 1)
```

Here's a quick fix, that does the job for us: See: https://github.com/tutao/tutanota/pull/8424
However, I am not sure which other targets require a similar fix.

What do you think @thomwiggers @charlag ?