### PR TITLE
Fix building on aarch64 (fixes #77)

### DIFF
--- a/pqcrypto-internals/build.rs
+++ b/pqcrypto-internals/build.rs
@@ -62,7 +62,7 @@ fn main() {
         println!("cargo:rustc-link-lib=keccak4x")
     } else if target_arch == "aarch64" && target_env != "msvc" {
         builder
-            .flag("-march=armv8-a+sha3")
+            .flag("-march=armv8.2-a+sha3")
             .file(cfiledir.join("keccak2x").join("fips202x2.c"))
             .file(cfiledir.join("keccak2x").join("feat.S"))
             .compile("keccak2x");


### PR DESCRIPTION
armv8-a does not actually support sha3, we need at least armv8.2-a.
See https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html.
Thank you!