### PR TITLE
Harden secret material handling in McEliece bindings and add zeroization

### DIFF
--- a/pqcrypto-classicmceliece/Cargo.toml
+++ b/pqcrypto-classicmceliece/Cargo.toml
@@ -17,6 +17,7 @@ pqcrypto-traits = { path = "../pqcrypto-traits", version = "0.3.5", default-feat
 libc = "0.2.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde-big-array = { version = "0.5.1", optional = true }
+zeroize = "1"
 
 [features]
 default = ["avx2", "std"]

--- a/pqcrypto-classicmceliece/src/mceliece348864f.rs
+++ b/pqcrypto-classicmceliece/src/mceliece348864f.rs
@@ -1,6 +1,6 @@
 //! mceliece348864f
 //!
-//! These bindings use the clean version from [PQClean][pqc]
+//! These bindings prefer AVX2 when available and fall back to the clean implementation from [PQClean][pqc]
 //!
 //! # Example
 //! ```
@@ -97,18 +97,62 @@ simple_struct!(
     PublicKey,
     ffi::PQCLEAN_MCELIECE348864F_CLEAN_CRYPTO_PUBLICKEYBYTES
 );
-simple_struct!(
-    SecretKey,
-    ffi::PQCLEAN_MCELIECE348864F_CLEAN_CRYPTO_SECRETKEYBYTES
-);
+/// Secret key bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SecretKey(pub [u8; ffi::PQCLEAN_MCELIECE348864F_CLEAN_CRYPTO_SECRETKEYBYTES]);
+
+impl core::fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SecretKey ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SecretKey {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SecretKey {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 simple_struct!(
     Ciphertext,
     ffi::PQCLEAN_MCELIECE348864F_CLEAN_CRYPTO_CIPHERTEXTBYTES
 );
-simple_struct!(
-    SharedSecret,
-    ffi::PQCLEAN_MCELIECE348864F_CLEAN_CRYPTO_BYTES
-);
+/// Shared secret bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SharedSecret(pub [u8; ffi::PQCLEAN_MCELIECE348864F_CLEAN_CRYPTO_BYTES]);
+
+impl core::fmt::Debug for SharedSecret {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SharedSecret ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SharedSecret {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SharedSecret {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SharedSecret {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 
 /// Get the number of bytes for a public key
 pub const fn public_key_bytes() -> usize {

--- a/pqcrypto-classicmceliece/src/mceliece460896.rs
+++ b/pqcrypto-classicmceliece/src/mceliece460896.rs
@@ -1,6 +1,6 @@
 //! mceliece460896
 //!
-//! These bindings use the clean version from [PQClean][pqc]
+//! These bindings prefer AVX2 when available and fall back to the clean implementation from [PQClean][pqc]
 //!
 //! # Example
 //! ```
@@ -97,15 +97,62 @@ simple_struct!(
     PublicKey,
     ffi::PQCLEAN_MCELIECE460896_CLEAN_CRYPTO_PUBLICKEYBYTES
 );
-simple_struct!(
-    SecretKey,
-    ffi::PQCLEAN_MCELIECE460896_CLEAN_CRYPTO_SECRETKEYBYTES
-);
+/// Secret key bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SecretKey(pub [u8; ffi::PQCLEAN_MCELIECE460896_CLEAN_CRYPTO_SECRETKEYBYTES]);
+
+impl core::fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SecretKey ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SecretKey {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SecretKey {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 simple_struct!(
     Ciphertext,
     ffi::PQCLEAN_MCELIECE460896_CLEAN_CRYPTO_CIPHERTEXTBYTES
 );
-simple_struct!(SharedSecret, ffi::PQCLEAN_MCELIECE460896_CLEAN_CRYPTO_BYTES);
+/// Shared secret bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SharedSecret(pub [u8; ffi::PQCLEAN_MCELIECE460896_CLEAN_CRYPTO_BYTES]);
+
+impl core::fmt::Debug for SharedSecret {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SharedSecret ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SharedSecret {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SharedSecret {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SharedSecret {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 
 /// Get the number of bytes for a public key
 pub const fn public_key_bytes() -> usize {

--- a/pqcrypto-classicmceliece/src/mceliece460896f.rs
+++ b/pqcrypto-classicmceliece/src/mceliece460896f.rs
@@ -1,6 +1,6 @@
 //! mceliece460896f
 //!
-//! These bindings use the clean version from [PQClean][pqc]
+//! These bindings prefer AVX2 when available and fall back to the clean implementation from [PQClean][pqc]
 //!
 //! # Example
 //! ```
@@ -97,18 +97,62 @@ simple_struct!(
     PublicKey,
     ffi::PQCLEAN_MCELIECE460896F_CLEAN_CRYPTO_PUBLICKEYBYTES
 );
-simple_struct!(
-    SecretKey,
-    ffi::PQCLEAN_MCELIECE460896F_CLEAN_CRYPTO_SECRETKEYBYTES
-);
+/// Secret key bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SecretKey(pub [u8; ffi::PQCLEAN_MCELIECE460896F_CLEAN_CRYPTO_SECRETKEYBYTES]);
+
+impl core::fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SecretKey ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SecretKey {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SecretKey {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 simple_struct!(
     Ciphertext,
     ffi::PQCLEAN_MCELIECE460896F_CLEAN_CRYPTO_CIPHERTEXTBYTES
 );
-simple_struct!(
-    SharedSecret,
-    ffi::PQCLEAN_MCELIECE460896F_CLEAN_CRYPTO_BYTES
-);
+/// Shared secret bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SharedSecret(pub [u8; ffi::PQCLEAN_MCELIECE460896F_CLEAN_CRYPTO_BYTES]);
+
+impl core::fmt::Debug for SharedSecret {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SharedSecret ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SharedSecret {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SharedSecret {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SharedSecret {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 
 /// Get the number of bytes for a public key
 pub const fn public_key_bytes() -> usize {

--- a/pqcrypto-classicmceliece/src/mceliece6688128.rs
+++ b/pqcrypto-classicmceliece/src/mceliece6688128.rs
@@ -1,6 +1,6 @@
 //! mceliece6688128
 //!
-//! These bindings use the clean version from [PQClean][pqc]
+//! These bindings prefer AVX2 when available and fall back to the clean implementation from [PQClean][pqc]
 //!
 //! # Example
 //! ```no_run
@@ -97,18 +97,62 @@ simple_struct!(
     PublicKey,
     ffi::PQCLEAN_MCELIECE6688128_CLEAN_CRYPTO_PUBLICKEYBYTES
 );
-simple_struct!(
-    SecretKey,
-    ffi::PQCLEAN_MCELIECE6688128_CLEAN_CRYPTO_SECRETKEYBYTES
-);
+/// Secret key bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SecretKey(pub [u8; ffi::PQCLEAN_MCELIECE6688128_CLEAN_CRYPTO_SECRETKEYBYTES]);
+
+impl core::fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SecretKey ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SecretKey {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SecretKey {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 simple_struct!(
     Ciphertext,
     ffi::PQCLEAN_MCELIECE6688128_CLEAN_CRYPTO_CIPHERTEXTBYTES
 );
-simple_struct!(
-    SharedSecret,
-    ffi::PQCLEAN_MCELIECE6688128_CLEAN_CRYPTO_BYTES
-);
+/// Shared secret bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SharedSecret(pub [u8; ffi::PQCLEAN_MCELIECE6688128_CLEAN_CRYPTO_BYTES]);
+
+impl core::fmt::Debug for SharedSecret {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SharedSecret ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SharedSecret {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SharedSecret {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SharedSecret {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 
 /// Get the number of bytes for a public key
 pub const fn public_key_bytes() -> usize {

--- a/pqcrypto-classicmceliece/src/mceliece6688128f.rs
+++ b/pqcrypto-classicmceliece/src/mceliece6688128f.rs
@@ -1,6 +1,6 @@
 //! mceliece6688128f
 //!
-//! These bindings use the clean version from [PQClean][pqc]
+//! These bindings prefer AVX2 when available and fall back to the clean implementation from [PQClean][pqc]
 //!
 //! # Example
 //! ```no_run
@@ -97,18 +97,62 @@ simple_struct!(
     PublicKey,
     ffi::PQCLEAN_MCELIECE6688128F_CLEAN_CRYPTO_PUBLICKEYBYTES
 );
-simple_struct!(
-    SecretKey,
-    ffi::PQCLEAN_MCELIECE6688128F_CLEAN_CRYPTO_SECRETKEYBYTES
-);
+/// Secret key bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SecretKey(pub [u8; ffi::PQCLEAN_MCELIECE6688128F_CLEAN_CRYPTO_SECRETKEYBYTES]);
+
+impl core::fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SecretKey ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SecretKey {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SecretKey {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 simple_struct!(
     Ciphertext,
     ffi::PQCLEAN_MCELIECE6688128F_CLEAN_CRYPTO_CIPHERTEXTBYTES
 );
-simple_struct!(
-    SharedSecret,
-    ffi::PQCLEAN_MCELIECE6688128F_CLEAN_CRYPTO_BYTES
-);
+/// Shared secret bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SharedSecret(pub [u8; ffi::PQCLEAN_MCELIECE6688128F_CLEAN_CRYPTO_BYTES]);
+
+impl core::fmt::Debug for SharedSecret {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SharedSecret ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SharedSecret {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SharedSecret {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SharedSecret {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 
 /// Get the number of bytes for a public key
 pub const fn public_key_bytes() -> usize {

--- a/pqcrypto-classicmceliece/src/mceliece6960119.rs
+++ b/pqcrypto-classicmceliece/src/mceliece6960119.rs
@@ -1,6 +1,6 @@
 //! mceliece6960119
 //!
-//! These bindings use the clean version from [PQClean][pqc]
+//! These bindings prefer AVX2 when available and fall back to the clean implementation from [PQClean][pqc]
 //!
 //! # Example
 //! ```no_run
@@ -97,18 +97,62 @@ simple_struct!(
     PublicKey,
     ffi::PQCLEAN_MCELIECE6960119_CLEAN_CRYPTO_PUBLICKEYBYTES
 );
-simple_struct!(
-    SecretKey,
-    ffi::PQCLEAN_MCELIECE6960119_CLEAN_CRYPTO_SECRETKEYBYTES
-);
+/// Secret key bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SecretKey(pub [u8; ffi::PQCLEAN_MCELIECE6960119_CLEAN_CRYPTO_SECRETKEYBYTES]);
+
+impl core::fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SecretKey ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SecretKey {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SecretKey {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 simple_struct!(
     Ciphertext,
     ffi::PQCLEAN_MCELIECE6960119_CLEAN_CRYPTO_CIPHERTEXTBYTES
 );
-simple_struct!(
-    SharedSecret,
-    ffi::PQCLEAN_MCELIECE6960119_CLEAN_CRYPTO_BYTES
-);
+/// Shared secret bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SharedSecret(pub [u8; ffi::PQCLEAN_MCELIECE6960119_CLEAN_CRYPTO_BYTES]);
+
+impl core::fmt::Debug for SharedSecret {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SharedSecret ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SharedSecret {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SharedSecret {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SharedSecret {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 
 /// Get the number of bytes for a public key
 pub const fn public_key_bytes() -> usize {

--- a/pqcrypto-classicmceliece/src/mceliece6960119f.rs
+++ b/pqcrypto-classicmceliece/src/mceliece6960119f.rs
@@ -1,6 +1,6 @@
 //! mceliece6960119f
 //!
-//! These bindings use the clean version from [PQClean][pqc]
+//! These bindings prefer AVX2 when available and fall back to the clean implementation from [PQClean][pqc]
 //!
 //! # Example
 //! ```no_run
@@ -97,18 +97,62 @@ simple_struct!(
     PublicKey,
     ffi::PQCLEAN_MCELIECE6960119F_CLEAN_CRYPTO_PUBLICKEYBYTES
 );
-simple_struct!(
-    SecretKey,
-    ffi::PQCLEAN_MCELIECE6960119F_CLEAN_CRYPTO_SECRETKEYBYTES
-);
+/// Secret key bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SecretKey(pub [u8; ffi::PQCLEAN_MCELIECE6960119F_CLEAN_CRYPTO_SECRETKEYBYTES]);
+
+impl core::fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SecretKey ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SecretKey {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SecretKey {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 simple_struct!(
     Ciphertext,
     ffi::PQCLEAN_MCELIECE6960119F_CLEAN_CRYPTO_CIPHERTEXTBYTES
 );
-simple_struct!(
-    SharedSecret,
-    ffi::PQCLEAN_MCELIECE6960119F_CLEAN_CRYPTO_BYTES
-);
+/// Shared secret bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SharedSecret(pub [u8; ffi::PQCLEAN_MCELIECE6960119F_CLEAN_CRYPTO_BYTES]);
+
+impl core::fmt::Debug for SharedSecret {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SharedSecret ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SharedSecret {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SharedSecret {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SharedSecret {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 
 /// Get the number of bytes for a public key
 pub const fn public_key_bytes() -> usize {

--- a/pqcrypto-classicmceliece/src/mceliece8192128.rs
+++ b/pqcrypto-classicmceliece/src/mceliece8192128.rs
@@ -1,6 +1,6 @@
 //! mceliece8192128
 //!
-//! These bindings use the clean version from [PQClean][pqc]
+//! These bindings prefer AVX2 when available and fall back to the clean implementation from [PQClean][pqc]
 //!
 //! # Example
 //! ```no_run
@@ -97,18 +97,62 @@ simple_struct!(
     PublicKey,
     ffi::PQCLEAN_MCELIECE8192128_CLEAN_CRYPTO_PUBLICKEYBYTES
 );
-simple_struct!(
-    SecretKey,
-    ffi::PQCLEAN_MCELIECE8192128_CLEAN_CRYPTO_SECRETKEYBYTES
-);
+/// Secret key bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SecretKey(pub [u8; ffi::PQCLEAN_MCELIECE8192128_CLEAN_CRYPTO_SECRETKEYBYTES]);
+
+impl core::fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SecretKey ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SecretKey {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SecretKey {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 simple_struct!(
     Ciphertext,
     ffi::PQCLEAN_MCELIECE8192128_CLEAN_CRYPTO_CIPHERTEXTBYTES
 );
-simple_struct!(
-    SharedSecret,
-    ffi::PQCLEAN_MCELIECE8192128_CLEAN_CRYPTO_BYTES
-);
+/// Shared secret bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SharedSecret(pub [u8; ffi::PQCLEAN_MCELIECE8192128_CLEAN_CRYPTO_BYTES]);
+
+impl core::fmt::Debug for SharedSecret {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SharedSecret ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SharedSecret {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SharedSecret {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SharedSecret {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 
 /// Get the number of bytes for a public key
 pub const fn public_key_bytes() -> usize {

--- a/pqcrypto-classicmceliece/src/mceliece8192128f.rs
+++ b/pqcrypto-classicmceliece/src/mceliece8192128f.rs
@@ -1,6 +1,6 @@
 //! mceliece8192128f
 //!
-//! These bindings use the clean version from [PQClean][pqc]
+//! These bindings prefer AVX2 when available and fall back to the clean implementation from [PQClean][pqc]
 //!
 //! # Example
 //! ```no_run
@@ -97,18 +97,62 @@ simple_struct!(
     PublicKey,
     ffi::PQCLEAN_MCELIECE8192128F_CLEAN_CRYPTO_PUBLICKEYBYTES
 );
-simple_struct!(
-    SecretKey,
-    ffi::PQCLEAN_MCELIECE8192128F_CLEAN_CRYPTO_SECRETKEYBYTES
-);
+/// Secret key bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SecretKey(pub [u8; ffi::PQCLEAN_MCELIECE8192128F_CLEAN_CRYPTO_SECRETKEYBYTES]);
+
+impl core::fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SecretKey ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SecretKey {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SecretKey {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 simple_struct!(
     Ciphertext,
     ffi::PQCLEAN_MCELIECE8192128F_CLEAN_CRYPTO_CIPHERTEXTBYTES
 );
-simple_struct!(
-    SharedSecret,
-    ffi::PQCLEAN_MCELIECE8192128F_CLEAN_CRYPTO_BYTES
-);
+/// Shared secret bytes; not `Copy`. Zeroized on drop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SharedSecret(pub [u8; ffi::PQCLEAN_MCELIECE8192128F_CLEAN_CRYPTO_BYTES]);
+
+impl core::fmt::Debug for SharedSecret {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SharedSecret ({} bytes)", self.0.len())
+    }
+}
+
+impl AsRef<[u8]> for SharedSecret {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsMut<[u8]> for SharedSecret {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl Drop for SharedSecret {
+    fn drop(&mut self) {
+        // Best-effort zeroization; requires `zeroize` at build time.
+        #[allow(unused_imports)]
+        use zeroize::Zeroize;
+        self.0.as_mut().zeroize();
+    }
+}
 
 /// Get the number of bytes for a public key
 pub const fn public_key_bytes() -> usize {


### PR DESCRIPTION
- Replaced `simple_struct!` for `SecretKey` and `SharedSecret` with
  explicit tuple structs.
- Removed `Copy` and `Serialize`/`Deserialize` derives to prevent
  accidental duplication or leakage of sensitive material.
- Added `Drop` impls with `zeroize` to securely wipe memory on drop.
- Left `PublicKey` and `Ciphertext` unchanged (still Copy + serde).
- Updated crate docs to state preference for AVX2 backend with clean fallback.