### PR TITLE
support pqcrypto in wasm unknown unknown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,33 @@ jobs:
           cargo install cargo-ndk
           cargo ndk -t aarch64-linux-android build
 
+  wasm32-unknown-unknown:
+    name: wasm32-unknown-unknown
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [ stable, beta, nightly ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install Rust
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --component clippy
+          rustup default ${{ matrix.rust }}
+          rustup target add wasm32-unknown-unknown
+
+      - name: Check workspace (all crates except classicmceliece & umbrella)
+        run: |
+          cargo check --workspace --target wasm32-unknown-unknown --features getrandom_wasm_js \
+            --exclude pqcrypto-classicmceliece \
+            --exclude pqcrypto
+
+      - name: Check umbrella crate (explicitly enable only supported wasm crates)
+        run: |
+          cargo check --target wasm32-unknown-unknown \
+            -p pqcrypto --no-default-features -F pqcrypto-mlkem,pqcrypto-hqc,pqcrypto-mldsa,pqcrypto-falcon,pqcrypto-sphincsplus,serialization,getrandom_wasm_js
   # wasi:
   #   name: wasi
   #   runs-on: ubuntu-latest

--- a/pqcrypto-classicmceliece/Cargo.toml
+++ b/pqcrypto-classicmceliece/Cargo.toml
@@ -14,15 +14,18 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 pqcrypto-internals = { path = "../pqcrypto-internals", version = "0.2.6" }
 pqcrypto-traits = { path = "../pqcrypto-traits", version = "0.3.5", default-features = false }
-libc = "0.2.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde-big-array = { version = "0.5.1", optional = true }
+
+[target.wasm32-unknown-unknown.dependencies]
+wasm32-unknown-unknown-openbsd-libc = "0.2"
 
 [features]
 default = ["avx2", "std"]
 avx2 = ["std"]
 std = ["pqcrypto-traits/std"]
 serialization = ["serde", "serde-big-array"]
+getrandom_wasm_js = ["pqcrypto-internals/getrandom_wasm_js"]
 
 [dev-dependencies]
 

--- a/pqcrypto-classicmceliece/build.rs
+++ b/pqcrypto-classicmceliece/build.rs
@@ -26,12 +26,17 @@ macro_rules! build_clean {
         builder
             .include(internals_include_path)
             .include(&common_dir)
-            .include(target_dir)
-            .files(
-                scheme_files
-                    .into_iter()
-                    .map(|p| p.unwrap().to_string_lossy().into_owned()),
-            );
+            .include(target_dir);
+        if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE") {
+            builder.include(libc);
+            println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
+        }
+
+        builder.files(
+            scheme_files
+                .into_iter()
+                .map(|p| p.unwrap().to_string_lossy().into_owned()),
+        );
         builder.compile(format!("{}_clean", $variant).as_str());
     };
 }
@@ -68,12 +73,17 @@ macro_rules! build_avx2 {
         builder
             .include(internals_include_path)
             .include(&common_dir)
-            .include(target_dir)
-            .files(
-                scheme_files
-                    .into_iter()
-                    .map(|p| p.unwrap().to_string_lossy().into_owned()),
-            );
+            .include(target_dir);
+        if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE") {
+            builder.include(libc);
+            println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
+        }
+
+        builder.files(
+            scheme_files
+                .into_iter()
+                .map(|p| p.unwrap().to_string_lossy().into_owned()),
+        );
         builder.compile(format!("{}_avx2", $variant).as_str());
     };
 }

--- a/pqcrypto-classicmceliece/src/ffi.rs
+++ b/pqcrypto-classicmceliece/src/ffi.rs
@@ -15,7 +15,7 @@
 //!  * mceliece8192128f
 // This file has been generated from PQClean.
 // Find the templates in pqcrypto-template
-use libc::c_int;
+use core::ffi::c_int;
 
 // ensures we link correctly
 #[allow(unused_imports)]

--- a/pqcrypto-falcon/Cargo.toml
+++ b/pqcrypto-falcon/Cargo.toml
@@ -18,12 +18,16 @@ libc = "0.2.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde-big-array = { version = "0.5.1", optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm32-unknown-unknown-openbsd-libc = "0.2"
+
 [features]
 default = ["avx2", "neon", "std"]
 avx2 = ["std"]
 neon = ["std"]
 std = ["pqcrypto-traits/std"]
 serialization = ["serde", "serde-big-array"]
+getrandom_wasm_js = ["pqcrypto-internals/getrandom_wasm_js"]
 
 [dev-dependencies]
 rand = "0.9"

--- a/pqcrypto-falcon/Cargo.toml
+++ b/pqcrypto-falcon/Cargo.toml
@@ -14,11 +14,10 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 pqcrypto-internals = { path = "../pqcrypto-internals", version = "0.2.6" }
 pqcrypto-traits = { path = "../pqcrypto-traits", version = "0.3.5", default-features = false }
-libc = "0.2.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde-big-array = { version = "0.5.1", optional = true }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.wasm32-unknown-unknown.dependencies]
 wasm32-unknown-unknown-openbsd-libc = "0.2"
 
 [features]

--- a/pqcrypto-falcon/build.rs
+++ b/pqcrypto-falcon/build.rs
@@ -14,9 +14,7 @@ macro_rules! build_clean {
             .iter()
             .collect();
 
-        let target = env::var("TARGET").unwrap_or_default();
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-
         if target_os == "wasi" {
             let wasi_sdk_path =
                 &std::env::var("WASI_SDK_DIR").expect("missing environment variable: WASI_SDK_DIR");
@@ -29,14 +27,9 @@ macro_rules! build_clean {
             .include(internals_include_path)
             .include(&common_dir)
             .include(target_dir);
-
-        // Add OpenBSD libc for WASM
-        if target.contains("wasm32") {
-            if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE")
-            {
-                builder.include(libc);
-                println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
-            }
+        if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE") {
+            builder.include(libc);
+            println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
         }
 
         builder.files(
@@ -58,9 +51,7 @@ macro_rules! build_avx2 {
             .iter()
             .collect();
 
-        let target = env::var("TARGET").unwrap_or_default();
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-
         if target_os == "wasi" {
             let wasi_sdk_path =
                 &std::env::var("WASI_SDK_DIR").expect("missing environment variable: WASI_SDK_DIR");
@@ -85,14 +76,9 @@ macro_rules! build_avx2 {
             .include(internals_include_path)
             .include(&common_dir)
             .include(target_dir);
-
-        // Add OpenBSD libc for WASM
-        if target.contains("wasm32") {
-            if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE")
-            {
-                builder.include(libc);
-                println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
-            }
+        if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE") {
+            builder.include(libc);
+            println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
         }
 
         builder.files(
@@ -114,9 +100,7 @@ macro_rules! build_aarch64 {
             .iter()
             .collect();
 
-        let target = env::var("TARGET").unwrap_or_default();
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-
         if target_os == "wasi" {
             let wasi_sdk_path =
                 &std::env::var("WASI_SDK_DIR").expect("missing environment variable: WASI_SDK_DIR");
@@ -130,14 +114,9 @@ macro_rules! build_aarch64 {
             .include(internals_include_path)
             .include(&common_dir)
             .include(target_dir);
-
-        // Add OpenBSD libc for WASM
-        if target.contains("wasm32") {
-            if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE")
-            {
-                builder.include(libc);
-                println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
-            }
+        if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE") {
+            builder.include(libc);
+            println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
         }
 
         builder.files(

--- a/pqcrypto-falcon/build.rs
+++ b/pqcrypto-falcon/build.rs
@@ -14,7 +14,9 @@ macro_rules! build_clean {
             .iter()
             .collect();
 
+        let target = env::var("TARGET").unwrap_or_default();
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+
         if target_os == "wasi" {
             let wasi_sdk_path =
                 &std::env::var("WASI_SDK_DIR").expect("missing environment variable: WASI_SDK_DIR");
@@ -26,12 +28,22 @@ macro_rules! build_clean {
         builder
             .include(internals_include_path)
             .include(&common_dir)
-            .include(target_dir)
-            .files(
-                scheme_files
-                    .into_iter()
-                    .map(|p| p.unwrap().to_string_lossy().into_owned()),
-            );
+            .include(target_dir);
+
+        // Add OpenBSD libc for WASM
+        if target.contains("wasm32") {
+            if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE")
+            {
+                builder.include(libc);
+                println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
+            }
+        }
+
+        builder.files(
+            scheme_files
+                .into_iter()
+                .map(|p| p.unwrap().to_string_lossy().into_owned()),
+        );
         builder.compile(format!("{}_clean", $variant).as_str());
     };
 }
@@ -46,7 +58,9 @@ macro_rules! build_avx2 {
             .iter()
             .collect();
 
+        let target = env::var("TARGET").unwrap_or_default();
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+
         if target_os == "wasi" {
             let wasi_sdk_path =
                 &std::env::var("WASI_SDK_DIR").expect("missing environment variable: WASI_SDK_DIR");
@@ -70,12 +84,22 @@ macro_rules! build_avx2 {
         builder
             .include(internals_include_path)
             .include(&common_dir)
-            .include(target_dir)
-            .files(
-                scheme_files
-                    .into_iter()
-                    .map(|p| p.unwrap().to_string_lossy().into_owned()),
-            );
+            .include(target_dir);
+
+        // Add OpenBSD libc for WASM
+        if target.contains("wasm32") {
+            if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE")
+            {
+                builder.include(libc);
+                println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
+            }
+        }
+
+        builder.files(
+            scheme_files
+                .into_iter()
+                .map(|p| p.unwrap().to_string_lossy().into_owned()),
+        );
         builder.compile(format!("{}_avx2", $variant).as_str());
     };
 }
@@ -90,7 +114,9 @@ macro_rules! build_aarch64 {
             .iter()
             .collect();
 
+        let target = env::var("TARGET").unwrap_or_default();
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+
         if target_os == "wasi" {
             let wasi_sdk_path =
                 &std::env::var("WASI_SDK_DIR").expect("missing environment variable: WASI_SDK_DIR");
@@ -103,12 +129,22 @@ macro_rules! build_aarch64 {
         builder
             .include(internals_include_path)
             .include(&common_dir)
-            .include(target_dir)
-            .files(
-                scheme_files
-                    .into_iter()
-                    .map(|p| p.unwrap().to_string_lossy().into_owned()),
-            );
+            .include(target_dir);
+
+        // Add OpenBSD libc for WASM
+        if target.contains("wasm32") {
+            if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE")
+            {
+                builder.include(libc);
+                println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
+            }
+        }
+
+        builder.files(
+            scheme_files
+                .into_iter()
+                .map(|p| p.unwrap().to_string_lossy().into_owned()),
+        );
         builder.compile(format!("{}_aarch64", $variant).as_str());
     };
 }

--- a/pqcrypto-falcon/src/ffi.rs
+++ b/pqcrypto-falcon/src/ffi.rs
@@ -9,6 +9,11 @@
 //!  * falcon-padded-1024
 // This file has been generated from PQClean.
 // Find the templates in pqcrypto-template
+
+#[cfg(target_arch = "wasm32")]
+use core::ffi::c_int;
+
+#[cfg(not(target_arch = "wasm32"))]
 use libc::c_int;
 
 // ensures we link correctly

--- a/pqcrypto-falcon/src/ffi.rs
+++ b/pqcrypto-falcon/src/ffi.rs
@@ -9,12 +9,7 @@
 //!  * falcon-padded-1024
 // This file has been generated from PQClean.
 // Find the templates in pqcrypto-template
-
-#[cfg(target_arch = "wasm32")]
 use core::ffi::c_int;
-
-#[cfg(not(target_arch = "wasm32"))]
-use libc::c_int;
 
 // ensures we link correctly
 #[allow(unused_imports)]

--- a/pqcrypto-hqc/Cargo.toml
+++ b/pqcrypto-hqc/Cargo.toml
@@ -14,14 +14,17 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 pqcrypto-internals = { path = "../pqcrypto-internals", version = "0.2.6" }
 pqcrypto-traits = { path = "../pqcrypto-traits", version = "0.3.5", default-features = false }
-libc = "0.2.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde-big-array = { version = "0.5.1", optional = true }
+
+[target.wasm32-unknown-unknown.dependencies]
+wasm32-unknown-unknown-openbsd-libc = "0.2"
 
 [features]
 default = ["std"]
 std = ["pqcrypto-traits/std"]
 serialization = ["serde", "serde-big-array"]
+getrandom_wasm_js = ["pqcrypto-internals/getrandom_wasm_js"]
 
 [dev-dependencies]
 

--- a/pqcrypto-hqc/build.rs
+++ b/pqcrypto-hqc/build.rs
@@ -26,12 +26,17 @@ macro_rules! build_clean {
         builder
             .include(internals_include_path)
             .include(&common_dir)
-            .include(target_dir)
-            .files(
-                scheme_files
-                    .into_iter()
-                    .map(|p| p.unwrap().to_string_lossy().into_owned()),
-            );
+            .include(target_dir);
+        if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE") {
+            builder.include(libc);
+            println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
+        }
+
+        builder.files(
+            scheme_files
+                .into_iter()
+                .map(|p| p.unwrap().to_string_lossy().into_owned()),
+        );
         builder.compile(format!("{}_clean", $variant).as_str());
     };
 }

--- a/pqcrypto-hqc/src/ffi.rs
+++ b/pqcrypto-hqc/src/ffi.rs
@@ -8,7 +8,7 @@
 //!  * hqc-256
 // This file has been generated from PQClean.
 // Find the templates in pqcrypto-template
-use libc::c_int;
+use core::ffi::c_int;
 
 // ensures we link correctly
 #[allow(unused_imports)]

--- a/pqcrypto-internals/Cargo.toml
+++ b/pqcrypto-internals/Cargo.toml
@@ -10,6 +10,9 @@ links = "pqcrypto_internals"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+getrandom_wasm_js = ["getrandom/wasm_js"]
+
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }
 dunce = "1.0"
@@ -17,3 +20,6 @@ dunce = "1.0"
 [dependencies]
 getrandom = "0.3"
 libc = "0.2"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm32-unknown-unknown-openbsd-libc = "0.2"

--- a/pqcrypto-internals/Cargo.toml
+++ b/pqcrypto-internals/Cargo.toml
@@ -19,7 +19,6 @@ dunce = "1.0"
 
 [dependencies]
 getrandom = "0.3"
-libc = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm32-unknown-unknown-openbsd-libc = "0.2"

--- a/pqcrypto-internals/build.rs
+++ b/pqcrypto-internals/build.rs
@@ -30,10 +30,14 @@ fn main() {
         build.flag(format!("--sysroot={wasi_sdk_path}").as_str());
     }
 
-    build
-        .include(&includepath)
-        .files(common_files)
-        .compile("pqclean_common");
+    build.include(&includepath);
+
+    if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE") {
+        build.include(libc);
+        println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
+    }
+
+    build.files(common_files).compile("pqclean_common");
     println!("cargo:rustc-link-lib=pqclean_common");
 
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();

--- a/pqcrypto-internals/src/lib.rs
+++ b/pqcrypto-internals/src/lib.rs
@@ -2,13 +2,9 @@
 
 use core::slice;
 
-#[cfg(target_arch = "wasm32")]
+#[allow(nonstandard_style)]
 type size_t = usize;
-#[cfg(target_arch = "wasm32")]
 use core::ffi::c_int;
-
-#[cfg(not(target_arch = "wasm32"))]
-use libc::{c_int, size_t};
 
 /// Get random bytes; exposed for PQClean implementations.
 ///

--- a/pqcrypto-internals/src/lib.rs
+++ b/pqcrypto-internals/src/lib.rs
@@ -2,6 +2,14 @@
 
 use core::slice;
 
+#[cfg(target_arch = "wasm32")]
+type size_t = usize;
+#[cfg(target_arch = "wasm32")]
+use core::ffi::c_int;
+
+#[cfg(not(target_arch = "wasm32"))]
+use libc::{c_int, size_t};
+
 /// Get random bytes; exposed for PQClean implementations.
 ///
 /// # Safety
@@ -16,7 +24,7 @@ use core::slice;
 /// }
 /// ```
 #[no_mangle]
-pub unsafe extern "C" fn PQCRYPTO_RUST_randombytes(buf: *mut u8, len: libc::size_t) -> libc::c_int {
+pub unsafe extern "C" fn PQCRYPTO_RUST_randombytes(buf: *mut u8, len: size_t) -> c_int {
     let buf = slice::from_raw_parts_mut(buf, len);
     getrandom::fill(buf).expect("RNG Failed");
     0

--- a/pqcrypto-mldsa/Cargo.toml
+++ b/pqcrypto-mldsa/Cargo.toml
@@ -14,10 +14,12 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 pqcrypto-internals = { path = "../pqcrypto-internals", version = "0.2.6" }
 pqcrypto-traits = { path = "../pqcrypto-traits", version = "0.3.5", default-features = false }
-libc = "0.2.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde-big-array = { version = "0.5.1", optional = true }
 paste = "1.0"
+
+[target.wasm32-unknown-unknown.dependencies]
+wasm32-unknown-unknown-openbsd-libc = "0.2"
 
 [features]
 default = ["avx2", "neon", "std"]
@@ -25,6 +27,7 @@ avx2 = ["std"]
 neon = ["std"]
 std = ["pqcrypto-traits/std"]
 serialization = ["serde", "serde-big-array"]
+getrandom_wasm_js = ["pqcrypto-internals/getrandom_wasm_js"]
 
 [dev-dependencies]
 rand = "0.9"

--- a/pqcrypto-mldsa/build.rs
+++ b/pqcrypto-mldsa/build.rs
@@ -26,12 +26,17 @@ macro_rules! build_clean {
         builder
             .include(internals_include_path)
             .include(&common_dir)
-            .include(target_dir)
-            .files(
-                scheme_files
-                    .into_iter()
-                    .map(|p| p.unwrap().to_string_lossy().into_owned()),
-            );
+            .include(target_dir);
+        if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE") {
+            builder.include(libc);
+            println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
+        }
+
+        builder.files(
+            scheme_files
+                .into_iter()
+                .map(|p| p.unwrap().to_string_lossy().into_owned()),
+        );
         builder.compile(format!("{}_clean", $variant).as_str());
     };
 }
@@ -70,12 +75,17 @@ macro_rules! build_avx2 {
         builder
             .include(internals_include_path)
             .include(&common_dir)
-            .include(target_dir)
-            .files(
-                scheme_files
-                    .into_iter()
-                    .map(|p| p.unwrap().to_string_lossy().into_owned()),
-            );
+            .include(target_dir);
+        if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE") {
+            builder.include(libc);
+            println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
+        }
+
+        builder.files(
+            scheme_files
+                .into_iter()
+                .map(|p| p.unwrap().to_string_lossy().into_owned()),
+        );
         builder.compile(format!("{}_avx2", $variant).as_str());
     };
 }
@@ -103,12 +113,17 @@ macro_rules! build_aarch64 {
         builder
             .include(internals_include_path)
             .include(&common_dir)
-            .include(target_dir)
-            .files(
-                scheme_files
-                    .into_iter()
-                    .map(|p| p.unwrap().to_string_lossy().into_owned()),
-            );
+            .include(target_dir);
+        if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE") {
+            builder.include(libc);
+            println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
+        }
+
+        builder.files(
+            scheme_files
+                .into_iter()
+                .map(|p| p.unwrap().to_string_lossy().into_owned()),
+        );
         builder.compile(format!("{}_aarch64", $variant).as_str());
     };
 }

--- a/pqcrypto-mldsa/src/ffi.rs
+++ b/pqcrypto-mldsa/src/ffi.rs
@@ -8,7 +8,7 @@
 //!  * ml-dsa-87
 // This file has been generated from PQClean.
 // Find the templates in pqcrypto-template
-use libc::c_int;
+use core::ffi::c_int;
 
 // ensures we link correctly
 #[allow(unused_imports)]

--- a/pqcrypto-mlkem/Cargo.toml
+++ b/pqcrypto-mlkem/Cargo.toml
@@ -14,9 +14,11 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 pqcrypto-internals = { path = "../pqcrypto-internals", version = "0.2.6" }
 pqcrypto-traits = { path = "../pqcrypto-traits", version = "0.3.5", default-features = false }
-libc = "0.2.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde-big-array = { version = "0.5.1", optional = true }
+
+[target.wasm32-unknown-unknown.dependencies]
+wasm32-unknown-unknown-openbsd-libc = "0.2"
 
 [features]
 default = ["avx2", "neon", "std"]
@@ -24,6 +26,7 @@ avx2 = ["std"]
 neon = ["std"]
 std = ["pqcrypto-traits/std"]
 serialization = ["serde", "serde-big-array"]
+getrandom_wasm_js = ["pqcrypto-internals/getrandom_wasm_js"]
 
 [dev-dependencies]
 

--- a/pqcrypto-mlkem/build.rs
+++ b/pqcrypto-mlkem/build.rs
@@ -26,12 +26,17 @@ macro_rules! build_clean {
         builder
             .include(internals_include_path)
             .include(&common_dir)
-            .include(target_dir)
-            .files(
-                scheme_files
-                    .into_iter()
-                    .map(|p| p.unwrap().to_string_lossy().into_owned()),
-            );
+            .include(target_dir);
+        if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE") {
+            builder.include(libc);
+            println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
+        }
+
+        builder.files(
+            scheme_files
+                .into_iter()
+                .map(|p| p.unwrap().to_string_lossy().into_owned()),
+        );
         builder.compile(format!("{}_clean", $variant).as_str());
     };
 }
@@ -68,12 +73,17 @@ macro_rules! build_avx2 {
         builder
             .include(internals_include_path)
             .include(&common_dir)
-            .include(target_dir)
-            .files(
-                scheme_files
-                    .into_iter()
-                    .map(|p| p.unwrap().to_string_lossy().into_owned()),
-            );
+            .include(target_dir);
+        if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE") {
+            builder.include(libc);
+            println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
+        }
+
+        builder.files(
+            scheme_files
+                .into_iter()
+                .map(|p| p.unwrap().to_string_lossy().into_owned()),
+        );
         builder.compile(format!("{}_avx2", $variant).as_str());
     };
 }
@@ -101,12 +111,17 @@ macro_rules! build_aarch64 {
         builder
             .include(internals_include_path)
             .include(&common_dir)
-            .include(target_dir)
-            .files(
-                scheme_files
-                    .into_iter()
-                    .map(|p| p.unwrap().to_string_lossy().into_owned()),
-            );
+            .include(target_dir);
+        if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE") {
+            builder.include(libc);
+            println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
+        }
+
+        builder.files(
+            scheme_files
+                .into_iter()
+                .map(|p| p.unwrap().to_string_lossy().into_owned()),
+        );
         builder.compile(format!("{}_aarch64", $variant).as_str());
     };
 }

--- a/pqcrypto-mlkem/src/ffi.rs
+++ b/pqcrypto-mlkem/src/ffi.rs
@@ -8,7 +8,7 @@
 //!  * ml-kem-1024
 // This file has been generated from PQClean.
 // Find the templates in pqcrypto-template
-use libc::c_int;
+use core::ffi::c_int;
 
 // ensures we link correctly
 #[allow(unused_imports)]

--- a/pqcrypto-sphincsplus/Cargo.toml
+++ b/pqcrypto-sphincsplus/Cargo.toml
@@ -14,15 +14,18 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 pqcrypto-internals = { path = "../pqcrypto-internals", version = "0.2.6" }
 pqcrypto-traits = { path = "../pqcrypto-traits", version = "0.3.5", default-features = false }
-libc = "0.2.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde-big-array = { version = "0.5.1", optional = true }
+
+[target.wasm32-unknown-unknown.dependencies]
+wasm32-unknown-unknown-openbsd-libc = "0.2"
 
 [features]
 default = ["avx2", "std"]
 avx2 = ["std"]
 std = ["pqcrypto-traits/std"]
 serialization = ["serde", "serde-big-array"]
+getrandom_wasm_js = ["pqcrypto-internals/getrandom_wasm_js"]
 
 [dev-dependencies]
 rand = "0.9"

--- a/pqcrypto-sphincsplus/build.rs
+++ b/pqcrypto-sphincsplus/build.rs
@@ -26,12 +26,17 @@ macro_rules! build_clean {
         builder
             .include(internals_include_path)
             .include(&common_dir)
-            .include(target_dir)
-            .files(
-                scheme_files
-                    .into_iter()
-                    .map(|p| p.unwrap().to_string_lossy().into_owned()),
-            );
+            .include(target_dir);
+        if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE") {
+            builder.include(libc);
+            println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
+        }
+
+        builder.files(
+            scheme_files
+                .into_iter()
+                .map(|p| p.unwrap().to_string_lossy().into_owned()),
+        );
         builder.compile(format!("{}_clean", $variant).as_str());
     };
 }
@@ -70,12 +75,17 @@ macro_rules! build_avx2 {
         builder
             .include(internals_include_path)
             .include(&common_dir)
-            .include(target_dir)
-            .files(
-                scheme_files
-                    .into_iter()
-                    .map(|p| p.unwrap().to_string_lossy().into_owned()),
-            );
+            .include(target_dir);
+        if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE") {
+            builder.include(libc);
+            println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
+        }
+
+        builder.files(
+            scheme_files
+                .into_iter()
+                .map(|p| p.unwrap().to_string_lossy().into_owned()),
+        );
         builder.compile(format!("{}_avx2", $variant).as_str());
     };
 }

--- a/pqcrypto-sphincsplus/src/ffi.rs
+++ b/pqcrypto-sphincsplus/src/ffi.rs
@@ -17,7 +17,7 @@
 //!  * sphincs-sha2-256s-simple
 // This file has been generated from PQClean.
 // Find the templates in pqcrypto-template
-use libc::c_int;
+use core::ffi::c_int;
 
 // ensures we link correctly
 #[allow(unused_imports)]

--- a/pqcrypto-template/pqcrypto/Cargo.toml.j2
+++ b/pqcrypto-template/pqcrypto/Cargo.toml.j2
@@ -21,6 +21,7 @@ pqcrypto-{{ name }} = { path = "../pqcrypto-{{ name }}", version = "{{ props.ver
 default = [{% for (name, props) in kems.items()|list + signs.items()|list %}{% if not props.insecure|default(False) %}"pqcrypto-{{name}}",{% endif %}{% endfor %}]
 cryptographically-insecure = [{% for (name, props) in kems.items()|list + signs.items()|list %}{% if props.insecure|default(False) %}"pqcrypto-{{name}}/cryptographically-insecure",{% endif %}{% endfor %}]
 serialization = [{% for (name, props) in kems.items()|list + signs.items()|list %}"pqcrypto-{{name}}/serialization",{% endfor %}]
+getrandom_wasm_jd = [{% for (name, props) in kems.items()|list + signs.items()|list %}"pqcrypto-{{name}}?/getrandom_wasm_js",{% endfor %}]
 
 [badges]
 travis-ci = { repository = "rustpq/pqcrypto", branch = "master" }

--- a/pqcrypto-template/pqcrypto/Cargo.toml.j2
+++ b/pqcrypto-template/pqcrypto/Cargo.toml.j2
@@ -20,8 +20,8 @@ pqcrypto-{{ name }} = { path = "../pqcrypto-{{ name }}", version = "{{ props.ver
 [features]
 default = [{% for (name, props) in kems.items()|list + signs.items()|list %}{% if not props.insecure|default(False) %}"pqcrypto-{{name}}",{% endif %}{% endfor %}]
 cryptographically-insecure = [{% for (name, props) in kems.items()|list + signs.items()|list %}{% if props.insecure|default(False) %}"pqcrypto-{{name}}/cryptographically-insecure",{% endif %}{% endfor %}]
-serialization = [{% for (name, props) in kems.items()|list + signs.items()|list %}"pqcrypto-{{name}}/serialization",{% endfor %}]
-getrandom_wasm_jd = [{% for (name, props) in kems.items()|list + signs.items()|list %}"pqcrypto-{{name}}?/getrandom_wasm_js",{% endfor %}]
+serialization = [{% for (name, props) in kems.items()|list + signs.items()|list %}"pqcrypto-{{name}}?/serialization",{% endfor %}]
+getrandom_wasm_js = [{% for (name, props) in kems.items()|list + signs.items()|list %}"pqcrypto-{{name}}?/getrandom_wasm_js",{% endfor %}]
 
 [badges]
 travis-ci = { repository = "rustpq/pqcrypto", branch = "master" }

--- a/pqcrypto-template/scheme/Cargo.toml.j2
+++ b/pqcrypto-template/scheme/Cargo.toml.j2
@@ -14,12 +14,14 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 pqcrypto-internals = { path = "../pqcrypto-internals", version = "0.2.6" }
 pqcrypto-traits = { path = "../pqcrypto-traits", version = "{{ traits_version }}", default-features = false }
-libc = "0.2.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde-big-array = { version = "0.5.1", optional = true }
 {% if supports_context %}
 paste = "1.0"
 {% endif %}
+
+[target.wasm32-unknown-unknown.dependencies]
+wasm32-unknown-unknown-openbsd-libc = "0.2"
 
 [features]
 default = [{% if 'avx2' in implementations or 'avx' in implementations %}"avx2", {% endif %}{% if 'aesni' in implementations %}"aes", {% endif %}{% if 'aarch64' in implementations %}"neon", {% endif %}"std"]
@@ -37,6 +39,7 @@ serialization = ["serde", "serde-big-array"]
 {% if insecure %}
 cryptographically-insecure = []
 {% endif %}
+getrandom_wasm_js = ["pqcrypto-internals/getrandom_wasm_js"]
 
 [dev-dependencies]
 {% if type == "sign" %}

--- a/pqcrypto-template/scheme/build.rs.j2
+++ b/pqcrypto-template/scheme/build.rs.j2
@@ -62,8 +62,15 @@ macro_rules! build_{{ implementation }} {
         builder
             .include(internals_include_path)
             .include(&common_dir)
-            .include(target_dir)
-            .files(
+            .include(target_dir);
+        {% if name != 'classicmceliece2' %}
+        if let Some(libc) = std::env::var_os("DEP_WASM32_UNKNOWN_UNKNOWN_OPENBSD_LIBC_INCLUDE") {
+            builder.include(libc);
+            println!("cargo::rustc-link-lib=wasm32-unknown-unknown-openbsd-libc");
+        }
+        {% endif %}
+
+        builder.files(
                 scheme_files
                     .into_iter()
                     .map(|p| p.unwrap().to_string_lossy().into_owned()),

--- a/pqcrypto-template/scheme/src/ffi.rs.j2
+++ b/pqcrypto-template/scheme/src/ffi.rs.j2
@@ -7,7 +7,7 @@
 {% endfor %}
 // This file has been generated from PQClean.
 // Find the templates in pqcrypto-template
-use libc::c_int;
+use core::ffi::c_int;
 
 // ensures we link correctly
 #[allow(unused_imports)]

--- a/pqcrypto/Cargo.toml
+++ b/pqcrypto/Cargo.toml
@@ -24,6 +24,7 @@ pqcrypto-sphincsplus = { path = "../pqcrypto-sphincsplus", version = "0.7.2", op
 default = ["pqcrypto-mlkem","pqcrypto-classicmceliece","pqcrypto-hqc","pqcrypto-mldsa","pqcrypto-falcon","pqcrypto-sphincsplus",]
 cryptographically-insecure = []
 serialization = ["pqcrypto-mlkem/serialization","pqcrypto-classicmceliece/serialization","pqcrypto-hqc/serialization","pqcrypto-mldsa/serialization","pqcrypto-falcon/serialization","pqcrypto-sphincsplus/serialization",]
+getrandom_wasm_jd = ["pqcrypto-falcon?/getrandom_wasm_js"]
 
 [badges]
 travis-ci = { repository = "rustpq/pqcrypto", branch = "master" }

--- a/pqcrypto/Cargo.toml
+++ b/pqcrypto/Cargo.toml
@@ -24,7 +24,7 @@ pqcrypto-sphincsplus = { path = "../pqcrypto-sphincsplus", version = "0.7.2", op
 default = ["pqcrypto-mlkem","pqcrypto-classicmceliece","pqcrypto-hqc","pqcrypto-mldsa","pqcrypto-falcon","pqcrypto-sphincsplus",]
 cryptographically-insecure = []
 serialization = ["pqcrypto-mlkem/serialization","pqcrypto-classicmceliece/serialization","pqcrypto-hqc/serialization","pqcrypto-mldsa/serialization","pqcrypto-falcon/serialization","pqcrypto-sphincsplus/serialization",]
-getrandom_wasm_jd = ["pqcrypto-falcon?/getrandom_wasm_js"]
+getrandom_wasm_jd = ["pqcrypto-mlkem?/getrandom_wasm_js","pqcrypto-classicmceliece?/getrandom_wasm_js","pqcrypto-hqc?/getrandom_wasm_js","pqcrypto-mldsa?/getrandom_wasm_js","pqcrypto-falcon?/getrandom_wasm_js","pqcrypto-sphincsplus?/getrandom_wasm_js",]
 
 [badges]
 travis-ci = { repository = "rustpq/pqcrypto", branch = "master" }

--- a/pqcrypto/Cargo.toml
+++ b/pqcrypto/Cargo.toml
@@ -23,8 +23,8 @@ pqcrypto-sphincsplus = { path = "../pqcrypto-sphincsplus", version = "0.7.2", op
 [features]
 default = ["pqcrypto-mlkem","pqcrypto-classicmceliece","pqcrypto-hqc","pqcrypto-mldsa","pqcrypto-falcon","pqcrypto-sphincsplus",]
 cryptographically-insecure = []
-serialization = ["pqcrypto-mlkem/serialization","pqcrypto-classicmceliece/serialization","pqcrypto-hqc/serialization","pqcrypto-mldsa/serialization","pqcrypto-falcon/serialization","pqcrypto-sphincsplus/serialization",]
-getrandom_wasm_jd = ["pqcrypto-mlkem?/getrandom_wasm_js","pqcrypto-classicmceliece?/getrandom_wasm_js","pqcrypto-hqc?/getrandom_wasm_js","pqcrypto-mldsa?/getrandom_wasm_js","pqcrypto-falcon?/getrandom_wasm_js","pqcrypto-sphincsplus?/getrandom_wasm_js",]
+serialization = ["pqcrypto-mlkem?/serialization","pqcrypto-classicmceliece?/serialization","pqcrypto-hqc?/serialization","pqcrypto-mldsa?/serialization","pqcrypto-falcon?/serialization","pqcrypto-sphincsplus?/serialization",]
+getrandom_wasm_js = ["pqcrypto-mlkem?/getrandom_wasm_js","pqcrypto-classicmceliece?/getrandom_wasm_js","pqcrypto-hqc?/getrandom_wasm_js","pqcrypto-mldsa?/getrandom_wasm_js","pqcrypto-falcon?/getrandom_wasm_js","pqcrypto-sphincsplus?/getrandom_wasm_js",]
 
 [badges]
 travis-ci = { repository = "rustpq/pqcrypto", branch = "master" }


### PR DESCRIPTION
# PR Description

This PR adds support for the `wasm32-unknown-unknown` target to most `pqcrypto-*` crates (ML-KEM, ML-DSA, Falcon, HQC, SPHINCS+),

### Motivation

Rust's `wasm32-unknown-unknown` target is commonly used for  WebAssembly applications (e.g., via `wasm-bindgen`). Previously, `pqcrypto` crates did not compile on this target

### What this PR does

- Removes the unconditional dependency on the `libc` crate.
- Switches FFI types from `libc::c_int` to `core::ffi::c_int` (libc itself will reexport core according to the issue: https://github.com/rust-lang/libc/issues/4257)

- For the `wasm32-unknown-unknown` target, adds a conditional dependency on `wasm32-unknown-unknown-openbsd-libc = "0.2"` (see https://github.com/trevyn/wasm32-unknown-unknown-openbsd-libc).

- Adds `build.rs` logic to include the libc port's headers and link against it when targeting wasm, enabling compilation of C code in wasm.

- Introduces a `getrandom_wasm_js` feature that enables `getrandom = { features = ["wasm_js"] }`.
- Updates templates.
- Propagates the feature to the umbrella `pqcrypto` crate.

This allows successful compilation and execution in WASM. [simple example](https://github.com/biryukovmaxim/falcon-wasm-test)

### Usage examples

Compile a single crate:

```bash
cargo build --target wasm32-unknown-unknown \
  --features getrandom_wasm_js \
  -p pqcrypto-hqc